### PR TITLE
Make posix time conversion to microseconds

### DIFF
--- a/FprimeZephyrReference/Components/Drv/Rv3028Manager/Rv3028Manager.cpp
+++ b/FprimeZephyrReference/Components/Drv/Rv3028Manager/Rv3028Manager.cpp
@@ -36,9 +36,11 @@ void Rv3028Manager ::timeGetPort_handler(FwIndexType portNum, Fw::Time& time) {
     // Convert time to POSIX time_t format
     struct tm* time_tm = rtc_time_to_tm(&time_rtc);
     time_t time_posix = timeutil_timegm(time_tm);
+    uint64_t hardware_cycles = k_sec_to_cyc_floor64(time_posix);
+    uint32_t time_useconds = k_cyc_to_us_floor32(hardware_cycles);
 
     // Set FPrime time object
-    time.set(TimeBase::TB_WORKSTATION_TIME, 0, static_cast<U32>(time_posix), 0);
+    time.set(TimeBase::TB_WORKSTATION_TIME, 0, time_posix, time_useconds);
 }
 
 U32 Rv3028Manager ::timeRead_handler(FwIndexType portNum) {


### PR DESCRIPTION
This code is converting time from seconds (as an Epoch offset) to hardware cycles and then to microseconds.

**Note**: Truncating conversions. Other rounding methods can be used.

**Testing:**
It looks like FPrime is only calculating the microseconds every 1Hz. This is worth bringing up with Michael to see if there is some method to change it's rate group. It's not immediately obvious to me looking at the topology file.
<img width="1512" height="982" alt="Captura de pantalla 2025-09-22 a la(s) 19 40 14" src="https://github.com/user-attachments/assets/c1a28791-2a5e-4382-8bee-ef1a1b19cee5" />
