### PR TITLE
added action to increase disk size

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: easimon/maximize-build-space@master
       - uses: actions/checkout@v4
       - name: Build
         run: |


### PR DESCRIPTION
# Increased disk size for builds

## Description

Build was giving error: (System.IO.IOException: No space left on device :)

Found github action (https://github.com/marketplace/actions/maximize-build-disk-space) that supposodely increases disk size for the github action build.

