### PR TITLE
Delete img/diagram.svg:Zone.Identifier

### DIFF
--- a/FprimeZephyrReference/Components/Watchdog/docs/img/diagram.svg:Zone.Identifier
+++ b/FprimeZephyrReference/Components/Watchdog/docs/img/diagram.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=vscode-webview://06sutmqocciejudt1q6dk9i4j0ftrdfegqfv7aiu1ujtv9um6nfr/


### PR DESCRIPTION
This file causes git checkout to fail on Windows. It is not used.
Resolves #23 
