### PR TITLE
Fix the RTC Test

### DIFF
--- a/FprimeZephyrReference/test/int/rtc_test.py
+++ b/FprimeZephyrReference/test/int/rtc_test.py
@@ -98,7 +98,7 @@ def test_02_time_incrementing(fprime_test_api: IntegrationTestAPI, start_gds):
 
     # Fetch initial time
     result: ChData = fprime_test_api.assert_telemetry(
-        f"{ina219SysManager}.Voltage", timeout = 3
+        f"{ina219SysManager}.Voltage", timeout=3
     )
 
     # Convert FPrime time to datetime
@@ -111,7 +111,7 @@ def test_02_time_incrementing(fprime_test_api: IntegrationTestAPI, start_gds):
 
     # Fetch updated time
     result: ChData = fprime_test_api.assert_telemetry(
-        f"{ina219SysManager}.Voltage", timeout = 3
+        f"{ina219SysManager}.Voltage", timeout=3
     )
 
     # Convert FPrime time to datetime


### PR DESCRIPTION
# Pull Request Title (e.g., Feature: Add user authentication)

## Description

The RTC tests were failing because we are not asserting in telemetry that is being automagically sent in group 1. This is now corrected.

## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?
<img width="1240" height="435" alt="Screenshot 2025-12-12 at 6 12 57 PM" src="https://github.com/user-attachments/assets/3db4d810-a4e0-4625-8418-34f15b7cd360" />

- [X] Integration tests

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
