### PR TITLE
passthrough doesnt switch too early

### DIFF
--- a/circuit-python-lora-passthrough/code.py
+++ b/circuit-python-lora-passthrough/code.py
@@ -22,6 +22,7 @@ rfm95.coding_rate = 5
 rfm95.preamble_length = 8
 packet_count = 0
 usb_cdc.console.timeout = 0.01
+data_console = b""
 print("[INFO] LoRa Receiver receiving packets")
 while True:
     # Look for a new packet - wait up to 2 seconds:
@@ -30,15 +31,17 @@ while True:
     if packet is not None:
         usb_cdc.data.write(packet)
         packet_count += 1
-    data = usb_cdc.console.read(3)
+    data_console += usb_cdc.console.read(3)
+    data_data = usb_cdc.data.read(usb_cdc.data.in_waiting)
+    if len(data_data) > 0:
+        rfm95.send(data_data)
+        continue
     try:
-        rate = int(data)
+        rate = int(data_console)
+        data_console = b""
         if rate < 7 or rate > 9:
             raise ValueError("Spreading factor must be between 7 and 9")
         print(f"[INFO] Setting spreading factor to {rate}")
         rfm95.spreading_factor = rate
     except (ValueError, TypeError):
         pass
-    data = usb_cdc.data.read(usb_cdc.data.in_waiting)
-    if len(data) > 0:
-        rfm95.send(data)

--- a/test/test_day_in_the_life.py
+++ b/test/test_day_in_the_life.py
@@ -4,6 +4,7 @@ This file contains tests for the day-in-the-life functionality of the Proves sys
 """
 
 import subprocess
+import time
 from pathlib import Path
 
 import serial
@@ -51,10 +52,11 @@ def test_02_run_radio_sequences(fprime_test_api):
     fprime_test_api.send_command(
         "ReferenceDeployment.cmdSeq.CS_RUN", ["/seq/radio-fast.bin", "BLOCK"]
     )
+    time.sleep(1)
     if pass_through_serial is not None:
         pass_through_serial.write(b"7\r\n")
     fprime_test_api.assert_event(
-        "ReferenceDeployment.downlinkDelay.DividerSet", [0], timeout=10
+        "ReferenceDeployment.downlinkDelay.DividerSet", [0], timeout=20
     )
 
 


### PR DESCRIPTION
# Fixes for DOL test

## Description

Makes passthrough not swithc early

## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Z Tests
- [ ] Manual testing (describe steps)

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
