### PR TITLE
Write new sequence number when dataIn_handler is called

### DIFF
--- a/FprimeZephyrReference/Components/Authenticate/Authenticate.cpp
+++ b/FprimeZephyrReference/Components/Authenticate/Authenticate.cpp
@@ -301,7 +301,7 @@ void Authenticate ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const 
     }
 
     // check the sequence number is valid
-    U32 expectedSeqNum = this->get_SequenceNumber();
+    U32 expectedSeqNum = this->sequenceNumber.load();
 
     bool sequenceNumberValid = this->validateSequenceNumber(sequenceNumber, expectedSeqNum);
     if (!sequenceNumberValid) {
@@ -312,6 +312,7 @@ void Authenticate ::dataIn_handler(FwIndexType portNum, Fw::Buffer& data, const 
     // increment the stored sequence number
     U32 newSequenceNumber = sequenceNumber + 1;
     this->sequenceNumber.store(newSequenceNumber);
+    this->writeSequenceNumber(SEQUENCE_NUMBER_PATH, newSequenceNumber);
     this->tlmWrite_CurrentSequenceNumber(newSequenceNumber);
 
     U32 newCount = this->m_authenticatedPacketsCount.fetch_add(1) + 1;


### PR DESCRIPTION
# Write new sequence number when dataIn_handler is called

## Description

Updates the `dataIn_handler` in the `Authenticate` component to increment the sequence number on the board when it is called. I also set it to read the sequence number from the class instead of the file, although that can be reverted if necessary.

## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?

Ran on the board and the sequence number stays in sync with the ground station plugin

- [ ] Unit tests
- [x] Integration tests
- [ ] Z Tests
- [x] Manual testing (describe steps)

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
