### PR TITLE
Detumble on 10Hz rate group

### DIFF
--- a/FprimeZephyrReference/Components/DetumbleManager/DetumbleManager.fpp
+++ b/FprimeZephyrReference/Components/DetumbleManager/DetumbleManager.fpp
@@ -29,10 +29,10 @@ module Components {
         param ROTATIONAL_THRESHOLD: F64 default 12.0 id 1
 
         @ Parameter for storing the cooldown duration
-        param COOLDOWN_DURATION: Fw.TimeIntervalValue default {seconds = 1, useconds = 0} id 3
+        param COOLDOWN_DURATION: Fw.TimeIntervalValue default {seconds = 0, useconds = 20000} id 3
 
         @ Parameter for storing the detumble torquing duration
-        param TORQUE_DURATION: Fw.TimeIntervalValue default {seconds = 3, useconds = 0} id 38
+        param TORQUE_DURATION: Fw.TimeIntervalValue default {seconds = 0, useconds = 20000} id 38
 
         ### Magnetorquer Properties Parameters ###
 

--- a/FprimeZephyrReference/ReferenceDeployment/Top/topology.fpp
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/topology.fpp
@@ -244,6 +244,7 @@ module ReferenceDeployment {
       rateGroup10Hz.RateGroupMemberOut[9] -> downlinkDelay.run
       rateGroup10Hz.RateGroupMemberOut[10] -> sband.run
       rateGroup10Hz.RateGroupMemberOut[11] -> comDelaySband.run
+      rateGroup10Hz.RateGroupMemberOut[12] -> detumbleManager.run
 
       # Slow rate (1Hz) rate group
       rateGroupDriver.CycleOut[Ports_RateGroups.rateGroup1Hz] -> rateGroup1Hz.CycleIn
@@ -265,7 +266,6 @@ module ReferenceDeployment {
       rateGroup1Hz.RateGroupMemberOut[16] -> modeManager.run
       rateGroup1Hz.RateGroupMemberOut[17] -> adcs.run
       rateGroup1Hz.RateGroupMemberOut[18] -> thermalManager.run
-      rateGroup1Hz.RateGroupMemberOut[19] -> detumbleManager.run
     }
 
 


### PR DESCRIPTION
# Pull Request Title (e.g., Feature: Add user authentication)

## Description

This PR puts the detumble component on a 10Hz rategroup for faster and more efficient detumble process. It requires #79 and #237.

I also tried simplifying the detumble component further and putting it on a 100Hz and a 50Hz rategroup but both of those rategroups slipped constantly and caused reboots.

## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Z Tests
- [ ] Manual testing (describe steps)

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
