### PR TITLE
Reduce unit-test time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,16 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download bin tools
-        if: steps.cache-bin.outputs.cache-hit != 'true'
-        run: |
-          make download-bin
-
-      - name: Setup submodules
-        if: steps.cache-submodules.outputs.cache-hit != 'true'
-        run: |
-          make submodules
-
       - name: Run Unit Tests
         run: |
           make test-unit


### PR DESCRIPTION
Unit tests are for vanilla cpp only right now so we shouldn't need any additional setup.