### PR TITLE
Enable microsecond timing

### DIFF
--- a/FprimeZephyrReference/Components/Drv/RtcManager/RtcManager.cpp
+++ b/FprimeZephyrReference/Components/Drv/RtcManager/RtcManager.cpp
@@ -28,10 +28,10 @@ void RtcManager ::configure(const struct device* dev) {
 // ----------------------------------------------------------------------
 
 void RtcManager ::timeGetPort_handler(FwIndexType portNum, Fw::Time& time) {
-    // Get system uptime
-    int64_t t = k_uptime_get();
-    U32 seconds_since_boot = static_cast<U32>(t / 1000);
-    U32 useconds_since_boot = static_cast<U32>((t % 1000) * 1000);
+    // Get system uptime in useconds
+    int64_t t = k_uptime_ticks();
+    U32 seconds_since_boot = static_cast<U32>(t / 1000000);
+    U32 useconds_since_boot = static_cast<U32>(t % 1000000);
 
     // Check device readiness
     if (!device_is_ready(this->m_dev)) {

--- a/prj.conf
+++ b/prj.conf
@@ -10,6 +10,10 @@ CONFIG_MAIN_STACK_SIZE=8192
 CONFIG_POSIX_API=y
 CONFIG_REBOOT=y
 
+#### System Clock Configuration ####
+# Run system clock at 1 MHz for microsecond precision timing
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000000
+
 #### Native USB ####
 #CONFIG_USB_DEVICE_STACK=y
 #CONFIG_USB_CDC_ACM=y


### PR DESCRIPTION
## Description
This PR enables microsecond timing, up from millisecond timing.

I've been working with timing in the 10ms range and it's a little odd to have only 1ms resolution when timing is slipping around. I'd like to increase the system clock resolution to microseconds to match FPrime's expectations.

Zephyr docs describe [`k_uptime_ticks()`](https://docs.zephyrproject.org/latest/doxygen/html/group__clock__apis.html#ga8f143af2ee4ad42d9f7817ef161cbd13) as

> the fundamental unit of resolution of kernel timekeeping.

Additionally I have been running with the `CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000000` config setting for a few days on the `detumble` branch and anecdotally the system is less likely to experience a rate group slip.

Example call added to the ADCS run handler:
```cpp
Fw::Time t = this->getTime();
Fw::Logger::log("ADCS Run Handler invoked at time: %u sec, %u usec\n", t.getSeconds(), t.getUSeconds());
```

Pre-change output:
```sh
[Os::Console] ADCS Run Handler invoked at time: 1767160726 sec, 661000 usec
```

Post-change output:
```sh
[Os::Console] ADCS Run Handler invoked at time: 1767160433 sec, 658244 usec
```

### RP2350 Clock Capable of Microsecond Timing
The Zephyr system clock uses an external crystal oscillator running at $12MHz$ and is checked by the system clock running at $150MHz$. We can see in the device tree that the crystal oscillator is defined as node `xosc` and that the system clock (`clk_sys`) references `xosc` via the `pll_sys` clock definition. We can validate this on the running system with:
```cpp
#include <zephyr/sys/printk.h>
#include <zephyr/device.h>
#include <zephyr/drivers/clock_control.h>
#include <zephyr/dt-bindings/clock/rpi_pico_rp2350_clock.h>

const struct device *clocks = DEVICE_DT_GET(DT_NODELABEL(clocks));

uint32_t rate;
clock_control_get_rate(clocks,
                       (clock_control_subsys_t)RPI_PICO_CLKID_CLK_SYS,
                       &rate);
printk("System clock rate: %u Hz\n", rate);
```

Where we see the output:
```sh
System clock rate: 150000000 Hz
```

Given that the crystal oscillator is expected to run at $12MHz$ we know that we have $10^{-8}$ precision in the clock and this PR sets the tick precision within that range since microseconds are $10^{-6}$.

#### References
- [8.1.2.3 Crystal Oscillator - RP2350 Datasheet](https://pip-assets.raspberrypi.com/categories/1214-rp2350/documents/RP-008373-DS-2-rp2350-datasheet.pdf?disposition=inline)
- [Crystal Oscillator (XOSC) Definition - Zephry RP2350 Device Tree](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi?plain=1#L164-L168)
- [System Clock Definition - Zephyr RP2350 Device Tree](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi?plain=1#L92-L98)
- [pll_sys Definition in the Zephyr Device Tree](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi?plain=1#L124-L133)

### `k_uptime_get()` Already Derived From Ticks

Calling `k_uptime_ticks()` reduces the call stack when getting time [because the call to `k_uptime_get()` derives millisecond timing return value from `k_uptime_ticks()`](https://github.com/zephyrproject-rtos/zephyr/blob/545c2870e9358d52e319b9ae301845e053376fe1/include/zephyr/kernel.h#L2070-L2086).

### Zephyr Microsecond Default
Zephyr defaults to $10000\ Ticks / s$ for [most devices](https://docs.zephyrproject.org/latest/kernel/services/timing/clocks.html). 

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Z Tests
- [x] Manual testing (describe steps)


