### PR TITLE
Revert clock tick change

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -10,10 +10,6 @@ CONFIG_MAIN_STACK_SIZE=8192
 CONFIG_POSIX_API=y
 CONFIG_REBOOT=y
 
-#### System Clock Configuration ####
-# Run system clock at 1 MHz for microsecond precision timing
-CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000000
-
 #### Native USB ####
 #CONFIG_USB_DEVICE_STACK=y
 #CONFIG_USB_CDC_ACM=y


### PR DESCRIPTION
## Description
I included this in #79 before I saw @LeStarch's feedback on #245. Reverting.

I have verified detumble continues to work on the 50Hz rate group without this change.