### PR TITLE
Comment out integration target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,54 +93,54 @@ jobs:
             build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json
           retention-days: 30
 
-  integration:
-    runs-on:
-      - integration
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v5
-
-      - name: Set up dependencies
-        run: |
-          make submodules fprime-venv
-
-      - name: Set Authentication Key
-        run: |
-          echo "#define AUTH_DEFAULT_KEY \"${{ secrets.AUTH_KEY }}\"" > FprimeZephyrReference/Components/Authenticate/AuthDefaultKey.h
-
-      - name: Install Framer Plugin
-        run: |
-          make framer-plugin
-
-      - name: Kill all python processes
-        run: |
-          pkill -9 python || true
-
-      - name: Sync Sequence Number
-        run: |
-          make sync-sequence-number
-
-      - name: Kill all python processes
-        run: |
-          pkill -9 python || true
-
-      - name: Trigger Bootloader
-        run: |
-          make bootloader
-          sleep 10
-
-      - name: Copy Firmware
-        run: |
-          picotool load ./bootable.uf2
-          picotool reboot
-          sleep 5
-
-      - name: Kill all python processes
-        run: |
-          pkill -9 python || true
-
-      - name: Run Integration Tests
-        run: |
-          make test-integration
+  # integration:
+  #   runs-on:
+  #     - integration
+  #   needs: build
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - uses: actions/download-artifact@v5
+  #
+  #     - name: Set up dependencies
+  #       run: |
+  #         make submodules fprime-venv
+  #
+  #     - name: Set Authentication Key
+  #       run: |
+  #         echo "#define AUTH_DEFAULT_KEY \"${{ secrets.AUTH_KEY }}\"" > FprimeZephyrReference/Components/Authenticate/AuthDefaultKey.h
+  #
+  #     - name: Install Framer Plugin
+  #       run: |
+  #         make framer-plugin
+  #
+  #     - name: Kill all python processes
+  #       run: |
+  #         pkill -9 python || true
+  #
+  #     - name: Sync Sequence Number
+  #       run: |
+  #         make sync-sequence-number
+  #
+  #     - name: Kill all python processes
+  #       run: |
+  #         pkill -9 python || true
+  #
+  #     - name: Trigger Bootloader
+  #       run: |
+  #         make bootloader
+  #         sleep 10
+  #
+  #     - name: Copy Firmware
+  #       run: |
+  #         picotool load ./bootable.uf2
+  #         picotool reboot
+  #         sleep 5
+  #
+  #     - name: Kill all python processes
+  #       run: |
+  #         pkill -9 python || true
+  #
+  #     - name: Run Integration Tests
+  #       run: |
+  #         make test-integration


### PR DESCRIPTION
As of right now, I'm fairly certain something related to telemetry delay instantly freezes the board when I try to run integration tests. Given this issue + a ton of the tests not working properly at the moment anyways, I think we should just remove the target until the tests are in a state where they're actually useful.