### PR TITLE
Fix safe sequencer

### DIFF
--- a/FprimeZephyrReference/Components/ModeManager/ModeManager.cpp
+++ b/FprimeZephyrReference/Components/ModeManager/ModeManager.cpp
@@ -313,7 +313,6 @@ void ModeManager ::loadState() {
     if (unintendedReboot) {
         // On unintended reboot, re-enter safe mode and run the safe mode sequence
         this->log_WARNING_HI_UnintendedRebootDetected();
-        this->runSafeModeSequence();
         this->enterSafeMode(Components::SafeModeReason::SYSTEM_FAULT);
     }
 


### PR DESCRIPTION
We are seeing issues with the system crashing into an unrecoverable state. Removing this line fixes the issue. We believe the sequence is attempting to run on boot before memory has been allocated which causes booting to fail.

**Reproduction steps:**
1. Checkout and build the commit after safe sequencer was merged
    ```sh
    git checkout be4aa15
    make submodules generate build
    ```
2. Upload the uf2 to the board
    ```sh
    cp bootable.uf2 /Volumes/RP2350
    ```
3. Run the following sequence to activate all the things
    ```sh
    R00:00:00 ReferenceDeployment.modeManager.EXIT_SAFE_MODE
    R00:00:00 ReferenceDeployment.lora.TRANSMIT, ENABLED
    R00:00:01 CdhCore.tlmSend.SET_LEVEL, 3
    R00:00:01 ReferenceDeployment.telemetryDelay.DIVIDER_PRM_SET, 10
    R00:00:01 ReferenceDeployment.downlinkDelay.DIVIDER_PRM_SET, 20
    R00:00:01 ReferenceDeployment.lora.DATA_RATE_PRM_SET, SF_7
    R00:00:02 ReferenceDeployment.face0LoadSwitch.TURN_ON
    R00:00:02 ReferenceDeployment.face1LoadSwitch.TURN_ON
    R00:00:02 ReferenceDeployment.face2LoadSwitch.TURN_ON
    R00:00:02 ReferenceDeployment.face3LoadSwitch.TURN_ON
    R00:00:03 ReferenceDeployment.face4LoadSwitch.TURN_ON
    R00:00:03 ReferenceDeployment.face5LoadSwitch.TURN_ON
    ```
4. Send a couple of noops
5. Restart the satellite with the foot switch. It will not reboot.
6. To restore functionality build and install the uf2 from the commit prior to the safe sequencer merge `2530fc46`