### PR TITLE
Detumble supports disconnected faces

### DIFF
--- a/FprimeZephyrReference/Components/ADCS/ADCS.fpp
+++ b/FprimeZephyrReference/Components/ADCS/ADCS.fpp
@@ -3,8 +3,11 @@ module Components {
     passive component ADCS {
         sync input port run: Svc.Sched
 
+        @ The number of light sensors on the ADCS
+        constant numLightSensors = 6
+
         @ Port for visible light from the light sensors
-        output port visibleLightGet: [6] Drv.lightGet
+        output port visibleLightGet: [numLightSensors] Drv.lightGet
 
         ###############################################################################
         # Standard AC Ports: Required for Channels, Events, Commands, and Parameters  #

--- a/FprimeZephyrReference/Components/DetumbleManager/DetumbleManager.cpp
+++ b/FprimeZephyrReference/Components/DetumbleManager/DetumbleManager.cpp
@@ -209,19 +209,39 @@ void DetumbleManager ::startMagnetorquers(I8 x_plus_drive_level,
                                           I8 y_plus_drive_level,
                                           I8 y_minus_drive_level,
                                           I8 z_minus_drive_level) {
-    this->xPlusStart_out(0, x_plus_drive_level);
-    this->xMinusStart_out(0, x_minus_drive_level);
-    this->yPlusStart_out(0, y_plus_drive_level);
-    this->yMinusStart_out(0, y_minus_drive_level);
-    this->zMinusStart_out(0, z_minus_drive_level);
+    if (isConnected_xPlusStart_OutputPort(0)) {
+        this->xPlusStart_out(0, x_plus_drive_level);
+    }
+    if (isConnected_xMinusStart_OutputPort(0)) {
+        this->xMinusStart_out(0, x_minus_drive_level);
+    }
+    if (isConnected_yPlusStart_OutputPort(0)) {
+        this->yPlusStart_out(0, y_plus_drive_level);
+    }
+    if (isConnected_yMinusStart_OutputPort(0)) {
+        this->yMinusStart_out(0, y_minus_drive_level);
+    }
+    if (isConnected_zMinusStart_OutputPort(0)) {
+        this->zMinusStart_out(0, z_minus_drive_level);
+    }
 }
 
 void DetumbleManager ::stopMagnetorquers() {
-    this->xPlusStop_out(0);
-    this->xMinusStop_out(0);
-    this->yPlusStop_out(0);
-    this->yMinusStop_out(0);
-    this->zMinusStop_out(0);
+    if (isConnected_xPlusStop_OutputPort(0)) {
+        this->xPlusStop_out(0);
+    }
+    if (isConnected_xMinusStop_OutputPort(0)) {
+        this->xMinusStop_out(0);
+    }
+    if (isConnected_yPlusStop_OutputPort(0)) {
+        this->yPlusStop_out(0);
+    }
+    if (isConnected_yMinusStop_OutputPort(0)) {
+        this->yMinusStop_out(0);
+    }
+    if (isConnected_zMinusStop_OutputPort(0)) {
+        this->zMinusStop_out(0);
+    }
 }
 
 void DetumbleManager ::stateCooldownActions() {

--- a/FprimeZephyrReference/Components/ThermalManager/ThermalManager.fpp
+++ b/FprimeZephyrReference/Components/ThermalManager/ThermalManager.fpp
@@ -4,12 +4,11 @@ module Components {
     passive component ThermalManager {
         sync input port run: Svc.Sched
 
-        # Output ports to  instances
+        @ The number of face temperature sensors
+        constant numFaceTempSensors = 5
 
         @ Port for face temperature sensors
-        output port faceTempGet: [5] Drv.temperatureGet
-
-        # Battery Cell
+        output port faceTempGet: [numFaceTempSensors] Drv.temperatureGet
 
         @ Port for battery cell temperature sensors
         output port battCellTempGet: [4] Drv.temperatureGet


### PR DESCRIPTION
## Description

Detumble now supports disconnected faces. This is helpful for satellites that do not have certain faces like the Columbia satellite.

Also extracted some constants in ADCS and Thermal managers which will help us configure satellites too.
