### PR TITLE
Increase Radio Fast Dividers

### DIFF
--- a/sequences/radio-fast.seq
+++ b/sequences/radio-fast.seq
@@ -4,7 +4,7 @@ R00:00:00 ReferenceDeployment.lora.TRANSMIT, DISABLED
 R00:00:01 ReferenceDeployment.lora.DATA_RATE_PRM_SET, SF_7
 R00:00:01 ReferenceDeployment.lora.BANDWIDTH_RX_PRM_SET, BW_500_KHZ
 R00:00:01 ReferenceDeployment.lora.TRANSMIT, ENABLED
-R00:00:00 ReferenceDeployment.downlinkDelay.DIVIDER_PRM_SET, 20
+R00:00:00 ReferenceDeployment.downlinkDelay.DIVIDER_PRM_SET, 19
 R00:00:00 ReferenceDeployment.telemetryDelay.DIVIDER_PRM_SET, 1
 
 ; Allow 15mins to "CANCEL" at higher data throughput


### PR DESCRIPTION
# Pull Request Title (e.g., Feature: Add user authentication)

## Description

Slight modification of the `radio-fast` sequence to make messages come out every 2seconds instead of as fast as possible. This is because setting the divider to 0 actually makes the satellite uncommandable due to how fast the downlink comes out. 

## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Z Tests
- [ ] Manual testing (describe steps)

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
