### PR TITLE
DRAFT Improve face sensor responsiveness

### DIFF
--- a/boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5.dtsi
+++ b/boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5.dtsi
@@ -196,6 +196,8 @@ zephyr_udc0: &usbd {
 		label = "TCA9548A";
 		reset-gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
 		i2c-mux-idle-disconnect;
+		clock-frequency = <400000>;
+		cq-size = <24>; // num sensors + 20%
 
 		mux_channel_0: i2c_mux@0 {
 			compatible = "ti,tca9548a-channel";

--- a/boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5.dtsi
+++ b/boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5.dtsi
@@ -196,7 +196,8 @@ zephyr_udc0: &usbd {
 		label = "TCA9548A";
 		reset-gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
 		i2c-mux-idle-disconnect;
-		clock-frequency = <400000>;
+		clock-frequency = <400000>; // Max freq for TCA9548A
+		sq-size = <24>; // num sensors + 20%
 		cq-size = <24>; // num sensors + 20%
 
 		mux_channel_0: i2c_mux@0 {

--- a/boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5.dtsi
+++ b/boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5.dtsi
@@ -196,9 +196,6 @@ zephyr_udc0: &usbd {
 		label = "TCA9548A";
 		reset-gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
 		i2c-mux-idle-disconnect;
-		clock-frequency = <400000>; // Max freq for TCA9548A
-		sq-size = <24>; // num sensors + 20%
-		cq-size = <24>; // num sensors + 20%
 
 		mux_channel_0: i2c_mux@0 {
 			compatible = "ti,tca9548a-channel";
@@ -206,6 +203,9 @@ zephyr_udc0: &usbd {
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <400000>;
+			sq-size = <8>;
+			cq-size = <8>;
 
 			face0_temp_sens: tmp112@48 {
 				compatible = "ti,tmp112";
@@ -243,6 +243,9 @@ zephyr_udc0: &usbd {
 			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <400000>;
+			sq-size = <8>;
+			cq-size = <8>;
 
 			face1_temp_sens: tmp112@48 {
 				compatible = "ti,tmp112";
@@ -280,6 +283,9 @@ zephyr_udc0: &usbd {
 			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <400000>;
+			sq-size = <8>;
+			cq-size = <8>;
 
 			face2_temp_sens: tmp112@48 {
 				compatible = "ti,tmp112";
@@ -317,6 +323,9 @@ zephyr_udc0: &usbd {
 			reg = <3>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <400000>;
+			sq-size = <8>;
+			cq-size = <8>;
 
 			face3_temp_sens: tmp112@48 {
 				compatible = "ti,tmp112";
@@ -355,6 +364,10 @@ zephyr_udc0: &usbd {
 			reg = <4>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <400000>;
+			sq-size = <8>;
+			cq-size = <8>;
+
 			batt_cell1_temp_sens: tmp112@48 {
 				compatible = "ti,tmp112";
 				reg = <0x48>;
@@ -392,6 +405,9 @@ zephyr_udc0: &usbd {
 			reg = <5>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <400000>;
+			sq-size = <8>;
+			cq-size = <8>;
 
 			face5_temp_sens: tmp112@48 {
 				compatible = "ti,tmp112";
@@ -430,6 +446,9 @@ zephyr_udc0: &usbd {
 			reg = <6>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <400000>;
+			sq-size = <8>;
+			cq-size = <8>;
 
 			face6_temp_sens: tmp112@48 {
 				compatible = "ti,tmp112";
@@ -468,6 +487,10 @@ zephyr_udc0: &usbd {
 			reg = <7>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			clock-frequency = <400000>;
+			sq-size = <8>;
+			cq-size = <8>;
+
 			// TODO add top cap temp sensor (it's not a TMP112)
 			face7_light_sens: light@29 {
 				compatible = "vishay,veml6031";


### PR DESCRIPTION
## Description

It's extremely common to see errors in the GDS related to FPrime components being unable to communicate with sensors on the face boards. We believe this is caused by the mux either dropping messages to the sensors or dropping messages from the sensors. This draft PR attempts to resolve these issues by:
- increasing the speed of the mux so that it polls sensors more frequently
- increasing the message queue size to the number of sensors on the mux + 20%

This needs to be tested on a satellite with all faces and battery pack attached.

## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Z Tests
- [ ] Manual testing (describe steps)

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
