### PR TITLE
Comment out safe mode sequence call

### DIFF
--- a/FprimeZephyrReference/Components/ModeManager/ModeManager.cpp
+++ b/FprimeZephyrReference/Components/ModeManager/ModeManager.cpp
@@ -265,8 +265,10 @@ void ModeManager ::loadState() {
                 if (this->m_mode == SystemMode::SAFE_MODE) {
                     // Turn off non-critical components to match safe mode state
                     this->turnOffNonCriticalComponents();
+
+                    // TODO: commented out because this crashes the board on boot
                     // run radio safe to match default safe params
-                    this->runSafeModeSequence();
+                    // this->runSafeModeSequence();
 
                     // Log that we're restoring safe mode (not entering it fresh)
                     Fw::LogStringArg reasonStr("State restored from persistent storage");
@@ -317,7 +319,9 @@ void ModeManager ::loadState() {
         // (e.g., to reset radio parameters and enforce any transmit delay policy)
         this->log_WARNING_HI_UnintendedRebootDetected();
         this->enterSafeMode(Components::SafeModeReason::SYSTEM_FAULT);
-        this->runSafeModeSequence();
+
+        // TODO: commented out because this crashes the board on boot if ran
+        // this->runSafeModeSequence();
     }
 
     // Clear clean shutdown flag for next boot detection


### PR DESCRIPTION
# Comment out safe mode sequence call

## Description

Caused in #297 
When this function gets called, the board crashes on boot, so quickly that you can't even see logs through UART. Likely that the function is getting called before the command sequencer is ready. This should be looked at again soon, just commenting out for now so that main is functional.
 
## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Z Tests
- [x] Manual testing (describe steps)

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
