### PR TITLE
Fix fprime_gds import warning and document upstream datetime deprecation warning

### DIFF
--- a/PROVESFlightControllerReference/test/int/veml6031_test.py
+++ b/PROVESFlightControllerReference/test/int/veml6031_test.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 import pytest
 from common import proves_send_and_assert_command
-from fprime.common.models.serialize.numerical_types import F32Type
+from fprime_gds.common.models.serialize.numerical_types import F32Type
 from fprime_gds.common.data_types.event_data import EventData
 from fprime_gds.common.models.serialize.time_type import TimeType
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI


### PR DESCRIPTION
Fix fprime_gds import warning and document upstream datetime deprecation warning
Closes #334 

## Description

**Summary**

This PR addresses warnings seen during integration test runs.

**Fix Implemented**
- Package Warning – fprime-gds not found
- Root cause: Package naming changed from fprime to fprime_gds.
- Result: Warning is fully resolved and dependency installation works correctly.

**Remaining Warning (Not Fixable in This PR)**

- UTC Datetime Deprecation Warning
- Root cause: Warning originates from upstream dependency code (not from our codebase).

**Why not fixed here:**
- Modifying dependency source is not maintainable.
- Local patches would be overwritten on upgrades.
- Correct solution: Wait for upstream fix and update dependency once released.

**Status**
- Package warning → Fixed
- UTC deprecation warning → Pending upstream fix

## Related Issues/Tickets

<!-- Closes #334  -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [PROVESFlightControllerReference/test/int/veml6031_test.py ] Integration tests\

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
