### PR TITLE
Comment out battery temp throttle clear

### DIFF
--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
@@ -51,12 +51,12 @@ void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
         if (temperature < BATT_CELL_TEMP_LOWER_THRESHOLD) {
             this->log_WARNING_LO_BatteryCellTemperatureBelowThreshold(i, temperature);
         } else if (temperature > BATT_CELL_TEMP_LOWER_THRESHOLD + ThermalManager::DEBOUNCE_ERROR) {
-            this->log_WARNING_LO_BatteryCellTemperatureBelowThreshold_ThrottleClear();
+            // this->log_WARNING_LO_BatteryCellTemperatureBelowThreshold_ThrottleClear();
         }
         if (temperature > BATT_CELL_TEMP_UPPER_THRESHOLD) {
             this->log_WARNING_LO_BatteryCellTemperatureAboveThreshold(i, temperature);
         } else if (temperature < BATT_CELL_TEMP_UPPER_THRESHOLD - ThermalManager::DEBOUNCE_ERROR) {
-            this->log_WARNING_LO_BatteryCellTemperatureAboveThreshold_ThrottleClear();
+            // this->log_WARNING_LO_BatteryCellTemperatureAboveThreshold_ThrottleClear();
         }
     }
 


### PR DESCRIPTION
The throttle clear functionality has a logical error that causes the event to keep getting unthrottled for a failing temperature cell when a different cell succeeds. Just commenting out the throttle clear for now while @JamesDCowley works on a proper solution.