### PR TITLE
Fix Temperature Threshold Events and Improve Thermal Manager

### DIFF
--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
@@ -33,30 +33,46 @@ void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
     // Face temp sensors
     for (FwIndexType i = 0; i < this->getNum_faceTempGet_OutputPorts(); i++) {
         F64 temperature = this->faceTempGet_out(i, condition);
+
         if (temperature < FACE_TEMP_LOWER_THRESHOLD) {
-            this->log_WARNING_LO_FaceTemperatureBelowThreshold(i, temperature);
+            if (!this->m_faceTempBelowActive[i]) {
+                this->m_faceTempBelowActive[i] = true;
+                this->log_WARNING_LO_FaceTemperatureBelowThreshold(i, temperature);
+            }
         } else if (temperature > FACE_TEMP_LOWER_THRESHOLD + ThermalManager::DEBOUNCE_ERROR) {
-            this->log_WARNING_LO_FaceTemperatureBelowThreshold_ThrottleClear();
+            this->m_faceTempBelowActive[i] = false;
         }
+
         if (temperature > FACE_TEMP_UPPER_THRESHOLD) {
-            this->log_WARNING_LO_FaceTemperatureAboveThreshold(i, temperature);
+            if (!this->m_faceTempAboveActive[i]) {
+                this->m_faceTempAboveActive[i] = true;
+                this->log_WARNING_LO_FaceTemperatureAboveThreshold(i, temperature);
+            }
         } else if (temperature < FACE_TEMP_UPPER_THRESHOLD - ThermalManager::DEBOUNCE_ERROR) {
-            this->log_WARNING_LO_FaceTemperatureAboveThreshold_ThrottleClear();
+            this->m_faceTempAboveActive[i] = false;
         }
     }
 
     // Battery cell temp sensors
     for (FwIndexType i = 0; i < this->getNum_battCellTempGet_OutputPorts(); i++) {
         F64 temperature = this->battCellTempGet_out(i, condition);
+
         if (temperature < BATT_CELL_TEMP_LOWER_THRESHOLD) {
-            this->log_WARNING_LO_BatteryCellTemperatureBelowThreshold(i, temperature);
+            if (!this->m_battCellTempBelowActive[i]) {
+                this->m_battCellTempBelowActive[i] = true;
+                this->log_WARNING_LO_BatteryCellTemperatureBelowThreshold(i, temperature);
+            }
         } else if (temperature > BATT_CELL_TEMP_LOWER_THRESHOLD + ThermalManager::DEBOUNCE_ERROR) {
-            // this->log_WARNING_LO_BatteryCellTemperatureBelowThreshold_ThrottleClear();
+            this->m_battCellTempBelowActive[i] = false;
         }
+
         if (temperature > BATT_CELL_TEMP_UPPER_THRESHOLD) {
-            this->log_WARNING_LO_BatteryCellTemperatureAboveThreshold(i, temperature);
+            if (!this->m_battCellTempAboveActive[i]) {
+                this->m_battCellTempAboveActive[i] = true;
+                this->log_WARNING_LO_BatteryCellTemperatureAboveThreshold(i, temperature);
+            }
         } else if (temperature < BATT_CELL_TEMP_UPPER_THRESHOLD - ThermalManager::DEBOUNCE_ERROR) {
-            // this->log_WARNING_LO_BatteryCellTemperatureAboveThreshold_ThrottleClear();
+            this->m_battCellTempAboveActive[i] = false;
         }
     }
 

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
@@ -28,7 +28,8 @@ void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
     for (FwIndexType i = 0; i < this->getNum_faceTempGet_OutputPorts(); i++) {
         const F64 temperature = this->faceTempGet_out(i, condition);
         if (condition == Fw::Success::SUCCESS) {  // Only evaluate thresholds if temperature reading was successful
-            this->evaluateTemperatureThreshold(i, temperature, this->faceTempThrottleActive[i],
+            this->evaluateTemperatureThreshold(i, temperature, this->faceAboveTemperatureThrottleActive[i],
+                                               this->faceBelowTemperatureThrottleActive[i],
                                                Components::ThermalManager_TempSensorType::FACE);
         }
     }
@@ -37,7 +38,8 @@ void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
     for (FwIndexType i = 0; i < this->getNum_battCellTempGet_OutputPorts(); i++) {
         const F64 temperature = this->battCellTempGet_out(i, condition);
         if (condition == Fw::Success::SUCCESS) {  // Only evaluate thresholds if temperature reading was successful
-            this->evaluateTemperatureThreshold(i, temperature, this->battCellTempThrottleActive[i],
+            this->evaluateTemperatureThreshold(i, temperature, this->battCellAboveTemperatureThrottleActive[i],
+                                               this->battCellBelowTemperatureThrottleActive[i],
                                                Components::ThermalManager_TempSensorType::BATTERY);
         }
     }
@@ -50,9 +52,10 @@ void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
 // Private helper methods
 // ----------------------------------------------------------------------
 
-void ThermalManager::evaluateTemperatureThreshold(FwIndexType idx,
+void ThermalManager::evaluateTemperatureThreshold(U32 idx,
                                                   F64 temperature,
-                                                  bool& throttleActive,
+                                                  bool& aboveTemperatureThrottleActive,
+                                                  bool& belowTemperatureThrottleActive,
                                                   Components::ThermalManager_TempSensorType sensorType) {
     Fw::ParamValid param_valid;
     F64 lowerThreshold = 0.0;
@@ -66,21 +69,24 @@ void ThermalManager::evaluateTemperatureThreshold(FwIndexType idx,
         upperThreshold = this->paramGet_BATT_CELL_TEMP_UPPER_THRESHOLD(param_valid);
     }
 
-    if (!throttleActive && temperature < lowerThreshold) {
-        throttleActive = true;
-        this->log_WARNING_LO_TemperatureBelowThreshold(sensorType, static_cast<U32>(idx), temperature);
+    // Check below temperature threshold
+    if (!belowTemperatureThrottleActive && temperature < lowerThreshold) {
+        belowTemperatureThrottleActive = true;
+        this->log_WARNING_LO_TemperatureBelowThreshold(sensorType, idx, temperature);
         return;
     }
-
-    if (!throttleActive && temperature > upperThreshold) {
-        throttleActive = true;
-        this->log_WARNING_LO_TemperatureAboveThreshold(sensorType, static_cast<U32>(idx), temperature);
-        return;
+    if (temperature > (lowerThreshold + ThermalManager::DEBOUNCE_ERROR)) {
+        belowTemperatureThrottleActive = false;
     }
 
-    if (throttleActive && temperature > (lowerThreshold + ThermalManager::DEBOUNCE_ERROR) &&
-        temperature < (upperThreshold - ThermalManager::DEBOUNCE_ERROR)) {
-        throttleActive = false;
+    // Check above temperature threshold
+    if (!aboveTemperatureThrottleActive && temperature > upperThreshold) {
+        aboveTemperatureThrottleActive = true;
+        this->log_WARNING_LO_TemperatureAboveThreshold(sensorType, idx, temperature);
+        return;
+    }
+    if (temperature < (upperThreshold - ThermalManager::DEBOUNCE_ERROR)) {
+        aboveTemperatureThrottleActive = false;
     }
 }
 

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
@@ -23,22 +23,13 @@ ThermalManager::~ThermalManager() {}
 
 void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
     Fw::Success condition;
-    Fw::ParamValid param_valid;
-
-    const F64 FACE_TEMP_LOWER_THRESHOLD = this->paramGet_FACE_TEMP_LOWER_THRESHOLD(param_valid);
-    const F64 FACE_TEMP_UPPER_THRESHOLD = this->paramGet_FACE_TEMP_UPPER_THRESHOLD(param_valid);
-    const F64 BATT_CELL_TEMP_LOWER_THRESHOLD = this->paramGet_BATT_CELL_TEMP_LOWER_THRESHOLD(param_valid);
-    const F64 BATT_CELL_TEMP_UPPER_THRESHOLD = this->paramGet_BATT_CELL_TEMP_UPPER_THRESHOLD(param_valid);
 
     // Face temp sensors
     for (FwIndexType i = 0; i < this->getNum_faceTempGet_OutputPorts(); i++) {
         const F64 temperature = this->faceTempGet_out(i, condition);
         if (condition == Fw::Success::SUCCESS) {  // Only evaluate thresholds if temperature reading was successful
-            this->evaluateTemperatureThreshold(i, temperature, FACE_TEMP_LOWER_THRESHOLD, FACE_TEMP_UPPER_THRESHOLD,
-                                               this->faceTempBelowThrottleActive[i],
-                                               this->faceTempAboveThrottleActive[i],
-                                               &ThermalManager::log_WARNING_LO_FaceTemperatureBelowThreshold,
-                                               &ThermalManager::log_WARNING_LO_FaceTemperatureAboveThreshold);
+            this->evaluateTemperatureThreshold(i, temperature, this->faceTempThrottleActive[i],
+                                               Components::ThermalManager_TempSensorType::FACE);
         }
     }
 
@@ -46,11 +37,8 @@ void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
     for (FwIndexType i = 0; i < this->getNum_battCellTempGet_OutputPorts(); i++) {
         const F64 temperature = this->battCellTempGet_out(i, condition);
         if (condition == Fw::Success::SUCCESS) {  // Only evaluate thresholds if temperature reading was successful
-            this->evaluateTemperatureThreshold(i, temperature, BATT_CELL_TEMP_LOWER_THRESHOLD,
-                                               BATT_CELL_TEMP_UPPER_THRESHOLD, this->battCellTempBelowThrottleActive[i],
-                                               this->battCellTempAboveThrottleActive[i],
-                                               &ThermalManager::log_WARNING_LO_BatteryCellTemperatureBelowThreshold,
-                                               &ThermalManager::log_WARNING_LO_BatteryCellTemperatureAboveThreshold);
+            this->evaluateTemperatureThreshold(i, temperature, this->battCellTempThrottleActive[i],
+                                               Components::ThermalManager_TempSensorType::BATTERY);
         }
     }
 
@@ -64,28 +52,36 @@ void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
 
 void ThermalManager::evaluateTemperatureThreshold(FwIndexType idx,
                                                   F64 temperature,
-                                                  F64 lowerThreshold,
-                                                  F64 upperThreshold,
-                                                  bool& belowThrottleActive,
-                                                  bool& aboveThrottleActive,
-                                                  LogFn logBelow,
-                                                  LogFn logAbove) {
-    if (temperature < lowerThreshold) {
-        if (!belowThrottleActive) {
-            belowThrottleActive = true;
-            (this->*logBelow)(static_cast<U32>(idx), static_cast<F32>(temperature));
-        }
-    } else if (temperature > lowerThreshold + ThermalManager::DEBOUNCE_ERROR) {
-        belowThrottleActive = false;
+                                                  bool& throttleActive,
+                                                  Components::ThermalManager_TempSensorType sensorType) {
+    Fw::ParamValid param_valid;
+    F64 lowerThreshold = 0.0;
+    F64 upperThreshold = 0.0;
+
+    if (sensorType == Components::ThermalManager_TempSensorType::FACE) {
+        lowerThreshold = this->paramGet_FACE_TEMP_LOWER_THRESHOLD(param_valid);
+        upperThreshold = this->paramGet_FACE_TEMP_UPPER_THRESHOLD(param_valid);
+    } else {
+        lowerThreshold = this->paramGet_BATT_CELL_TEMP_LOWER_THRESHOLD(param_valid);
+        upperThreshold = this->paramGet_BATT_CELL_TEMP_UPPER_THRESHOLD(param_valid);
     }
 
-    if (temperature > upperThreshold) {
-        if (!aboveThrottleActive) {
-            aboveThrottleActive = true;
-            (this->*logAbove)(static_cast<U32>(idx), static_cast<F32>(temperature));
-        }
-    } else if (temperature < upperThreshold - ThermalManager::DEBOUNCE_ERROR) {
-        aboveThrottleActive = false;
+    if (temperature < lowerThreshold && !throttleActive) {
+        throttleActive = true;
+        this->log_WARNING_LO_TemperatureBelowThreshold(sensorType, static_cast<U32>(idx), temperature);
+        return;
+    }
+
+    if (temperature > (lowerThreshold + ThermalManager::DEBOUNCE_ERROR)) {
+        throttleActive = false;
+    }
+    if (temperature > upperThreshold && !throttleActive) {
+        throttleActive = true;
+        this->log_WARNING_LO_TemperatureAboveThreshold(sensorType, static_cast<U32>(idx), temperature);
+        return;
+    }
+    if (temperature < (upperThreshold - ThermalManager::DEBOUNCE_ERROR)) {
+        throttleActive = false;
     }
 }
 

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
@@ -66,21 +66,20 @@ void ThermalManager::evaluateTemperatureThreshold(FwIndexType idx,
         upperThreshold = this->paramGet_BATT_CELL_TEMP_UPPER_THRESHOLD(param_valid);
     }
 
-    if (temperature < lowerThreshold && !throttleActive) {
+    if (!throttleActive && temperature < lowerThreshold) {
         throttleActive = true;
         this->log_WARNING_LO_TemperatureBelowThreshold(sensorType, static_cast<U32>(idx), temperature);
         return;
     }
 
-    if (temperature > (lowerThreshold + ThermalManager::DEBOUNCE_ERROR)) {
-        throttleActive = false;
-    }
-    if (temperature > upperThreshold && !throttleActive) {
+    if (!throttleActive && temperature > upperThreshold) {
         throttleActive = true;
         this->log_WARNING_LO_TemperatureAboveThreshold(sensorType, static_cast<U32>(idx), temperature);
         return;
     }
-    if (temperature < (upperThreshold - ThermalManager::DEBOUNCE_ERROR)) {
+
+    if (throttleActive && temperature > (upperThreshold + ThermalManager::DEBOUNCE_ERROR) &&
+        temperature < (upperThreshold - ThermalManager::DEBOUNCE_ERROR)) {
         throttleActive = false;
     }
 }

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
@@ -32,52 +32,61 @@ void ThermalManager::run_handler(FwIndexType portNum, U32 context) {
 
     // Face temp sensors
     for (FwIndexType i = 0; i < this->getNum_faceTempGet_OutputPorts(); i++) {
-        F64 temperature = this->faceTempGet_out(i, condition);
-
-        if (temperature < FACE_TEMP_LOWER_THRESHOLD) {
-            if (!this->m_faceTempBelowActive[i]) {
-                this->m_faceTempBelowActive[i] = true;
-                this->log_WARNING_LO_FaceTemperatureBelowThreshold(i, temperature);
-            }
-        } else if (temperature > FACE_TEMP_LOWER_THRESHOLD + ThermalManager::DEBOUNCE_ERROR) {
-            this->m_faceTempBelowActive[i] = false;
-        }
-
-        if (temperature > FACE_TEMP_UPPER_THRESHOLD) {
-            if (!this->m_faceTempAboveActive[i]) {
-                this->m_faceTempAboveActive[i] = true;
-                this->log_WARNING_LO_FaceTemperatureAboveThreshold(i, temperature);
-            }
-        } else if (temperature < FACE_TEMP_UPPER_THRESHOLD - ThermalManager::DEBOUNCE_ERROR) {
-            this->m_faceTempAboveActive[i] = false;
+        const F64 temperature = this->faceTempGet_out(i, condition);
+        if (condition == Fw::Success::SUCCESS) {  // Only evaluate thresholds if temperature reading was successful
+            this->evaluateTemperatureThreshold(i, temperature, FACE_TEMP_LOWER_THRESHOLD, FACE_TEMP_UPPER_THRESHOLD,
+                                               this->faceTempBelowThrottleActive[i],
+                                               this->faceTempAboveThrottleActive[i],
+                                               &ThermalManager::log_WARNING_LO_FaceTemperatureBelowThreshold,
+                                               &ThermalManager::log_WARNING_LO_FaceTemperatureAboveThreshold);
         }
     }
 
     // Battery cell temp sensors
     for (FwIndexType i = 0; i < this->getNum_battCellTempGet_OutputPorts(); i++) {
-        F64 temperature = this->battCellTempGet_out(i, condition);
-
-        if (temperature < BATT_CELL_TEMP_LOWER_THRESHOLD) {
-            if (!this->m_battCellTempBelowActive[i]) {
-                this->m_battCellTempBelowActive[i] = true;
-                this->log_WARNING_LO_BatteryCellTemperatureBelowThreshold(i, temperature);
-            }
-        } else if (temperature > BATT_CELL_TEMP_LOWER_THRESHOLD + ThermalManager::DEBOUNCE_ERROR) {
-            this->m_battCellTempBelowActive[i] = false;
-        }
-
-        if (temperature > BATT_CELL_TEMP_UPPER_THRESHOLD) {
-            if (!this->m_battCellTempAboveActive[i]) {
-                this->m_battCellTempAboveActive[i] = true;
-                this->log_WARNING_LO_BatteryCellTemperatureAboveThreshold(i, temperature);
-            }
-        } else if (temperature < BATT_CELL_TEMP_UPPER_THRESHOLD - ThermalManager::DEBOUNCE_ERROR) {
-            this->m_battCellTempAboveActive[i] = false;
+        const F64 temperature = this->battCellTempGet_out(i, condition);
+        if (condition == Fw::Success::SUCCESS) {  // Only evaluate thresholds if temperature reading was successful
+            this->evaluateTemperatureThreshold(i, temperature, BATT_CELL_TEMP_LOWER_THRESHOLD,
+                                               BATT_CELL_TEMP_UPPER_THRESHOLD, this->battCellTempBelowThrottleActive[i],
+                                               this->battCellTempAboveThrottleActive[i],
+                                               &ThermalManager::log_WARNING_LO_BatteryCellTemperatureBelowThreshold,
+                                               &ThermalManager::log_WARNING_LO_BatteryCellTemperatureAboveThreshold);
         }
     }
 
     // Pico temp sensor
     this->picoTempGet_out(0, condition);
+}
+
+// ----------------------------------------------------------------------
+// Private helper methods
+// ----------------------------------------------------------------------
+
+void ThermalManager::evaluateTemperatureThreshold(FwIndexType idx,
+                                                  F64 temperature,
+                                                  F64 lowerThreshold,
+                                                  F64 upperThreshold,
+                                                  bool& belowThrottleActive,
+                                                  bool& aboveThrottleActive,
+                                                  LogFn logBelow,
+                                                  LogFn logAbove) {
+    if (temperature < lowerThreshold) {
+        if (!belowThrottleActive) {
+            belowThrottleActive = true;
+            (this->*logBelow)(static_cast<U32>(idx), static_cast<F32>(temperature));
+        }
+    } else if (temperature > lowerThreshold + ThermalManager::DEBOUNCE_ERROR) {
+        belowThrottleActive = false;
+    }
+
+    if (temperature > upperThreshold) {
+        if (!aboveThrottleActive) {
+            aboveThrottleActive = true;
+            (this->*logAbove)(static_cast<U32>(idx), static_cast<F32>(temperature));
+        }
+    } else if (temperature < upperThreshold - ThermalManager::DEBOUNCE_ERROR) {
+        aboveThrottleActive = false;
+    }
 }
 
 }  // namespace Components

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
@@ -57,21 +57,28 @@ void ThermalManager::evaluateTemperatureThreshold(U32 idx,
                                                   bool& aboveTemperatureThrottleActive,
                                                   bool& belowTemperatureThrottleActive,
                                                   Components::ThermalManager_TempSensorType sensorType) {
+    // Initialize parameter values
     Fw::ParamValid param_valid;
     F64 lowerThreshold = 0.0;
     F64 upperThreshold = 0.0;
 
-    if (sensorType == Components::ThermalManager_TempSensorType::FACE) {
-        lowerThreshold = this->paramGet_FACE_TEMP_LOWER_THRESHOLD(param_valid);
-        upperThreshold = this->paramGet_FACE_TEMP_UPPER_THRESHOLD(param_valid);
-    } else {
-        lowerThreshold = this->paramGet_BATT_CELL_TEMP_LOWER_THRESHOLD(param_valid);
-        upperThreshold = this->paramGet_BATT_CELL_TEMP_UPPER_THRESHOLD(param_valid);
+    switch (sensorType) {
+        case Components::ThermalManager_TempSensorType::FACE:
+            lowerThreshold = this->paramGet_FACE_TEMP_LOWER_THRESHOLD(param_valid);
+            upperThreshold = this->paramGet_FACE_TEMP_UPPER_THRESHOLD(param_valid);
+            break;
+        case Components::ThermalManager_TempSensorType::BATTERY:
+            lowerThreshold = this->paramGet_BATT_CELL_TEMP_LOWER_THRESHOLD(param_valid);
+            upperThreshold = this->paramGet_BATT_CELL_TEMP_UPPER_THRESHOLD(param_valid);
+            break;
+        default:
+            FW_ASSERT(0, sensorType);  // Invalid temperature sensor type
     }
 
     // Check below temperature threshold
     if (!belowTemperatureThrottleActive && temperature < lowerThreshold) {
         belowTemperatureThrottleActive = true;
+        aboveTemperatureThrottleActive = false;
         this->log_WARNING_LO_TemperatureBelowThreshold(sensorType, idx, temperature);
         return;
     }
@@ -82,6 +89,7 @@ void ThermalManager::evaluateTemperatureThreshold(U32 idx,
     // Check above temperature threshold
     if (!aboveTemperatureThrottleActive && temperature > upperThreshold) {
         aboveTemperatureThrottleActive = true;
+        belowTemperatureThrottleActive = false;
         this->log_WARNING_LO_TemperatureAboveThreshold(sensorType, idx, temperature);
         return;
     }

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.cpp
@@ -78,7 +78,7 @@ void ThermalManager::evaluateTemperatureThreshold(FwIndexType idx,
         return;
     }
 
-    if (throttleActive && temperature > (upperThreshold + ThermalManager::DEBOUNCE_ERROR) &&
+    if (throttleActive && temperature > (lowerThreshold + ThermalManager::DEBOUNCE_ERROR) &&
         temperature < (upperThreshold - ThermalManager::DEBOUNCE_ERROR)) {
         throttleActive = false;
     }

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.fpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.fpp
@@ -35,26 +35,22 @@ module Components {
         @ Event for face temperature reading below threshold
         event FaceTemperatureBelowThreshold(sensorId: U32, temperature: F32) \
             severity warning low \
-            format "Face temperature below threshold: Sensor {} at {} °C" \
-            throttle 1
+            format "Face temperature below threshold: Sensor {} at {} °C"
 
         @ Event for face temperature reading above threshold
         event FaceTemperatureAboveThreshold(sensorId: U32, temperature: F32) \
             severity warning low \
-            format "Face temperature above threshold: Sensor {} at {} °C" \
-            throttle 1
+            format "Face temperature above threshold: Sensor {} at {} °C"
 
         @ Event for battery cell temperature reading below threshold
         event BatteryCellTemperatureBelowThreshold(sensorId: U32, temperature: F32) \
             severity warning low \
-            format "Battery cell temperature below threshold: Sensor {} at {} °C" \
-            throttle 1
+            format "Battery cell temperature below threshold: Sensor {} at {} °C"
 
         @ Event for battery cell temperature reading above threshold
         event BatteryCellTemperatureAboveThreshold(sensorId: U32, temperature: F32) \
             severity warning low \
-            format "Battery cell temperature above threshold: Sensor {} at {} °C" \
-            throttle 1
+            format "Battery cell temperature above threshold: Sensor {} at {} °C"
 
         ###############################################################################
         # Standard AC Ports: Required for Channels, Events, Commands, and Parameters  #

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.fpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.fpp
@@ -15,6 +15,12 @@ module Components {
         @ Parameter for battery cell temperature upper threshold in °C
         param BATT_CELL_TEMP_UPPER_THRESHOLD: F64 default 60.0 id 3
 
+        @ Enum for temperature sensor types
+        enum TempSensorType {
+            FACE,
+            BATTERY
+        }
+
         sync input port run: Svc.Sched
 
         @ The number of face temperature sensors
@@ -32,25 +38,15 @@ module Components {
         @ Port for Pico temperature sensor
         output port picoTempGet: Drv.picoTemperatureGet
 
-        @ Event for face temperature reading below threshold
-        event FaceTemperatureBelowThreshold(sensorId: U32, temperature: F32) \
+        @ Event for temperature reading below threshold
+        event TemperatureBelowThreshold(sensorType: TempSensorType, sensorId: U32, temperature: F64) \
             severity warning low \
-            format "Face temperature below threshold: Sensor {} at {} °C"
+            format "{} temperature below threshold: Sensor {} at {} °C"
 
-        @ Event for face temperature reading above threshold
-        event FaceTemperatureAboveThreshold(sensorId: U32, temperature: F32) \
+        @ Event for temperature reading above threshold
+        event TemperatureAboveThreshold(sensorType: TempSensorType, sensorId: U32, temperature: F64) \
             severity warning low \
-            format "Face temperature above threshold: Sensor {} at {} °C"
-
-        @ Event for battery cell temperature reading below threshold
-        event BatteryCellTemperatureBelowThreshold(sensorId: U32, temperature: F32) \
-            severity warning low \
-            format "Battery cell temperature below threshold: Sensor {} at {} °C"
-
-        @ Event for battery cell temperature reading above threshold
-        event BatteryCellTemperatureAboveThreshold(sensorId: U32, temperature: F32) \
-            severity warning low \
-            format "Battery cell temperature above threshold: Sensor {} at {} °C"
+            format "{} temperature above threshold: Sensor {} at {} °C"
 
         ###############################################################################
         # Standard AC Ports: Required for Channels, Events, Commands, and Parameters  #

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.hpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.hpp
@@ -24,7 +24,15 @@ class ThermalManager final : public ThermalManagerComponentBase {
     ~ThermalManager();
 
   private:
-    constexpr static F64 DEBOUNCE_ERROR = 3.0;  //!< Debounce error value for temperature threshold events
+    static constexpr F64 DEBOUNCE_ERROR = 3.0;  //!< Debounce error value for temperature threshold events
+    static constexpr U32 NUM_FACE_TEMP_SENSORS = 5;
+    static constexpr U32 NUM_BATT_CELL_TEMP_SENSORS = 4;
+
+    bool m_faceTempBelowActive[NUM_FACE_TEMP_SENSORS] = {false};
+    bool m_faceTempAboveActive[NUM_FACE_TEMP_SENSORS] = {false};
+    bool m_battCellTempBelowActive[NUM_BATT_CELL_TEMP_SENSORS] = {false};
+    bool m_battCellTempAboveActive[NUM_BATT_CELL_TEMP_SENSORS] = {false};
+
     // ----------------------------------------------------------------------
     // Handler implementations for typed input ports
     // ----------------------------------------------------------------------

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.hpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.hpp
@@ -25,15 +25,9 @@ class ThermalManager final : public ThermalManagerComponentBase {
 
   private:
     static constexpr F64 DEBOUNCE_ERROR = 3.0;  //!< Debounce error value for temperature threshold events
-    static constexpr U32 NUM_FACE_TEMP_SENSORS = 5;
-    static constexpr U32 NUM_BATT_CELL_TEMP_SENSORS = 4;
 
-    bool faceTempBelowThrottleActive[NUM_FACE_TEMP_SENSORS] = {false};
-    bool faceTempAboveThrottleActive[NUM_FACE_TEMP_SENSORS] = {false};
-    bool battCellTempBelowThrottleActive[NUM_BATT_CELL_TEMP_SENSORS] = {false};
-    bool battCellTempAboveThrottleActive[NUM_BATT_CELL_TEMP_SENSORS] = {false};
-
-    using LogFn = void (ThermalManager::*)(U32, F32) const;
+    bool faceTempThrottleActive[getNum_faceTempGet_OutputPorts()] = {false};
+    bool battCellTempThrottleActive[getNum_battCellTempGet_OutputPorts()] = {false};
 
     // ----------------------------------------------------------------------
     // Handler implementations for typed input ports
@@ -52,14 +46,11 @@ class ThermalManager final : public ThermalManagerComponentBase {
 
     //! Helper function to log temperature threshold events
     void evaluateTemperatureThreshold(
-        FwIndexType idx,            //!< The sensor index
-        F64 temperature,            //!< The temperature reading
-        F64 lowerThreshold,         //!< The lower temperature threshold
-        F64 upperThreshold,         //!< The upper temperature threshold
-        bool& belowThrottleActive,  //!< Whether the below threshold event throttle is currently active
-        bool& aboveThrottleActive,  //!< Whether the above threshold event throttle is currently active
-        LogFn logBelow,             //!< Log function for below threshold event
-        LogFn logAbove);            //!< Log function for above threshold event
+        FwIndexType idx,       //!< The sensor index
+        F64 temperature,       //!< The temperature reading
+        bool& throttleActive,  //!< Whether the threshold event throttle is currently active
+        Components::ThermalManager_TempSensorType sensorType  //!< The type of the temperature sensor
+    );
 };
 
 }  // namespace Components

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.hpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.hpp
@@ -28,10 +28,12 @@ class ThermalManager final : public ThermalManagerComponentBase {
     static constexpr U32 NUM_FACE_TEMP_SENSORS = 5;
     static constexpr U32 NUM_BATT_CELL_TEMP_SENSORS = 4;
 
-    bool m_faceTempBelowActive[NUM_FACE_TEMP_SENSORS] = {false};
-    bool m_faceTempAboveActive[NUM_FACE_TEMP_SENSORS] = {false};
-    bool m_battCellTempBelowActive[NUM_BATT_CELL_TEMP_SENSORS] = {false};
-    bool m_battCellTempAboveActive[NUM_BATT_CELL_TEMP_SENSORS] = {false};
+    bool faceTempBelowThrottleActive[NUM_FACE_TEMP_SENSORS] = {false};
+    bool faceTempAboveThrottleActive[NUM_FACE_TEMP_SENSORS] = {false};
+    bool battCellTempBelowThrottleActive[NUM_BATT_CELL_TEMP_SENSORS] = {false};
+    bool battCellTempAboveThrottleActive[NUM_BATT_CELL_TEMP_SENSORS] = {false};
+
+    using LogFn = void (ThermalManager::*)(U32, F32) const;
 
     // ----------------------------------------------------------------------
     // Handler implementations for typed input ports
@@ -43,6 +45,21 @@ class ThermalManager final : public ThermalManagerComponentBase {
     void run_handler(FwIndexType portNum,  //!< The port number
                      U32 context           //!< The call order
                      ) override;
+
+    // ----------------------------------------------------------------------
+    // Private helper methods
+    // ----------------------------------------------------------------------
+
+    //! Helper function to log temperature threshold events
+    void evaluateTemperatureThreshold(
+        FwIndexType idx,            //!< The sensor index
+        F64 temperature,            //!< The temperature reading
+        F64 lowerThreshold,         //!< The lower temperature threshold
+        F64 upperThreshold,         //!< The upper temperature threshold
+        bool& belowThrottleActive,  //!< Whether the below threshold event throttle is currently active
+        bool& aboveThrottleActive,  //!< Whether the above threshold event throttle is currently active
+        LogFn logBelow,             //!< Log function for below threshold event
+        LogFn logAbove);            //!< Log function for above threshold event
 };
 
 }  // namespace Components

--- a/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.hpp
+++ b/PROVESFlightControllerReference/Components/ThermalManager/ThermalManager.hpp
@@ -26,8 +26,10 @@ class ThermalManager final : public ThermalManagerComponentBase {
   private:
     static constexpr F64 DEBOUNCE_ERROR = 3.0;  //!< Debounce error value for temperature threshold events
 
-    bool faceTempThrottleActive[getNum_faceTempGet_OutputPorts()] = {false};
-    bool battCellTempThrottleActive[getNum_battCellTempGet_OutputPorts()] = {false};
+    bool faceAboveTemperatureThrottleActive[getNum_faceTempGet_OutputPorts()] = {false};
+    bool faceBelowTemperatureThrottleActive[getNum_faceTempGet_OutputPorts()] = {false};
+    bool battCellAboveTemperatureThrottleActive[getNum_battCellTempGet_OutputPorts()] = {false};
+    bool battCellBelowTemperatureThrottleActive[getNum_battCellTempGet_OutputPorts()] = {false};
 
     // ----------------------------------------------------------------------
     // Handler implementations for typed input ports
@@ -46,9 +48,10 @@ class ThermalManager final : public ThermalManagerComponentBase {
 
     //! Helper function to log temperature threshold events
     void evaluateTemperatureThreshold(
-        FwIndexType idx,       //!< The sensor index
-        F64 temperature,       //!< The temperature reading
-        bool& throttleActive,  //!< Whether the threshold event throttle is currently active
+        U32 idx,                    //!< The sensor index
+        F64 temperature,            //!< The temperature reading
+        bool& aboveThrottleActive,  //!< Whether the above threshold event throttle is currently active
+        bool& belowThrottleActive,  //!< Whether the below threshold event throttle is currently active
         Components::ThermalManager_TempSensorType sensorType  //!< The type of the temperature sensor
     );
 };

--- a/PROVESFlightControllerReference/Components/ThermalManager/docs/sdd.md
+++ b/PROVESFlightControllerReference/Components/ThermalManager/docs/sdd.md
@@ -15,6 +15,7 @@ The Thermal Manager component is designed to be scheduled periodically to trigge
    - Iterates through the connected battery cell temperature sensor ports.
    - Triggers temperature readings for each connected sensor.
    - Triggers temperature reading from the Pico die temperature sensor.
+   - Evaluates lower/upper threshold conditions per sensor
 
 ## Class Diagram
 
@@ -27,6 +28,7 @@ classDiagram
         class ThermalManager {
             + ThermalManager(const char* compName)
             + ~ThermalManager()
+            - evaluateTemperatureThreshold(FwIndexType idx, F64 temperature, F64 lowerThreshold, F64 upperThreshold, bool& belowActive, bool& aboveActive, LogFn logBelow, LogFn logAbove): void
             - run_handler(FwIndexType portNum, U32 context): void
         }
     }
@@ -99,8 +101,9 @@ sequenceDiagram
 
 ## Change Log
 
-| Date       | Description                                                           |
-| ---------- | --------------------------------------------------------------------- |
-| 2026-03-30 | Add Pico die temperature sensor integration                           |
-| 2026-03-30 | Add events for when temperature readings are above/below a threshold. |
-| 2025-12-05 | Initial Thermal Manager component SDD                                 |
+| Date       | Description                                                                                                                |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-01 | Updated threshold handling to use per-sensor state and shared evaluation logic; eliminated global throttle-clear behavior. |
+| 2026-03-30 | Add Pico die temperature sensor integration                                                                                |
+| 2026-03-30 | Add events for when temperature readings are above/below a threshold.                                                      |
+| 2025-12-05 | Initial Thermal Manager component SDD                                                                                      |

--- a/PROVESFlightControllerReference/Components/ThermalManager/docs/sdd.md
+++ b/PROVESFlightControllerReference/Components/ThermalManager/docs/sdd.md
@@ -15,7 +15,7 @@ The Thermal Manager component is designed to be scheduled periodically to trigge
    - Iterates through the connected battery cell temperature sensor ports.
    - Triggers temperature readings for each connected sensor.
    - Triggers temperature reading from the Pico die temperature sensor.
-   - Evaluates lower/upper threshold conditions per sensor
+   - Evaluates lower/upper threshold conditions for face and battery sensors with per-sensor hysteresis state
 
 ## Class Diagram
 
@@ -28,8 +28,8 @@ classDiagram
         class ThermalManager {
             + ThermalManager(const char* compName)
             + ~ThermalManager()
-            - evaluateTemperatureThreshold(FwIndexType idx, F64 temperature, F64 lowerThreshold, F64 upperThreshold, bool& belowActive, bool& aboveActive, LogFn logBelow, LogFn logAbove): void
             - run_handler(FwIndexType portNum, U32 context): void
+            - evaluateTemperatureThreshold(U32 idx, F64 temperature, bool& aboveThrottleActive, bool& belowThrottleActive, ThermalManager_TempSensorType sensorType): void
         }
     }
     ThermalManagerComponentBase <|-- ThermalManager : inherits
@@ -64,12 +64,10 @@ classDiagram
 
 ## Events
 
-| Name                                 | Description                                                                        |
-| ------------------------------------ | ---------------------------------------------------------------------------------- |
-| FaceTemperatureBelowThreshold        | Face temperature reading below threshold (Sensor ID and temperature in °C)         |
-| FaceTemperatureAboveThreshold        | Face temperature reading above threshold (Sensor ID and temperature in °C)         |
-| BatteryCellTemperatureBelowThreshold | Battery cell temperature reading below threshold (Sensor ID and temperature in °C) |
-| BatteryCellTemperatureAboveThreshold | Battery cell temperature reading above threshold (Sensor ID and temperature in °C) |
+| Name                      | Description                                                                                                                                    |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| TemperatureBelowThreshold | Event emitted when a face or battery sensor reading drops below its configured lower threshold; includes sensorType, sensorId, and temperature |
+| TemperatureAboveThreshold | Event emitted when a face or battery sensor reading exceeds its configured upper threshold; includes sensorType, sensorId, and temperature     |
 
 ## Sequence Diagrams
 
@@ -83,27 +81,31 @@ sequenceDiagram
     Scheduler-->>ThermalManager: run
     loop For each face sensor (0-4)
         ThermalManager->>Tmp112Manager: faceTempGet
+        ThermalManager->>ThermalManager: evaluateTemperatureThreshold
     end
     loop For each battery cell sensor (0-3)
         ThermalManager->>Tmp112Manager: battCellTempGet
+        ThermalManager->>ThermalManager: evaluateTemperatureThreshold
     end
     ThermalManager->>PicoTempManager: picoTempGet
 ```
 
 ## Requirements
 
-| Name                           | Description                                                                                                    | Validation                                                            |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Face Temperature Collection    | The component shall trigger data collection from connected face temperature sensors when run is called         | Verify all connected face temperature output ports are called         |
-| Battery Temperature Collection | The component shall trigger data collection from connected battery cell temperature sensors when run is called | Verify all connected battery cell temperature output ports are called |
-| Pico Temperature Collection    | The component shall trigger data collection from the Pico die temperature sensor when run is called            | Verify the Pico temperature output port is called                     |
-| Periodic Operation             | The component shall operate as a scheduled component responding to scheduler calls                             | Verify component responds correctly to scheduler input                |
+| Name                           | Description                                                                                                        | Validation                                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| Face Temperature Collection    | The component shall trigger data collection from connected face temperature sensors when run is called             | Verify all connected face temperature output ports are called                                       |
+| Battery Temperature Collection | The component shall trigger data collection from connected battery cell temperature sensors when run is called     | Verify all connected battery cell temperature output ports are called                               |
+| Pico Temperature Collection    | The component shall trigger data collection from the Pico die temperature sensor when run is called                | Verify the Pico temperature output port is called                                                   |
+| Threshold Monitoring           | The component shall emit threshold events when face or battery sensor temperatures cross configured bounds         | Verify `TemperatureBelowThreshold` and `TemperatureAboveThreshold` events are emitted appropriately |
+| Threshold Hysteresis           | The component shall suppress repeated threshold events until the measured temperature returns past a debounce band | Verify events are not re-emitted until the temperature re-enters the hysteresis band                |
+| Periodic Operation             | The component shall operate as a scheduled component responding to scheduler calls                                 | Verify component responds correctly to scheduler input                                              |
 
 ## Change Log
 
-| Date       | Description                                                                                                                |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------- |
-| 2026-05-01 | Updated threshold handling to use per-sensor state and shared evaluation logic; eliminated global throttle-clear behavior. |
-| 2026-03-30 | Add Pico die temperature sensor integration                                                                                |
-| 2026-03-30 | Add events for when temperature readings are above/below a threshold.                                                      |
-| 2025-12-05 | Initial Thermal Manager component SDD                                                                                      |
+| Date       | Description                                                                                                                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-07 | Updated threshold handling to use per-sensor state and shared evaluation logic; eliminated global throttle-clear behavior. Added evaluateTemperatureThreshold helper function, removed sensor-type specific threshold events. |
+| 2026-03-30 | Add Pico die temperature sensor integration                                                                                                                                                                                   |
+| 2026-03-30 | Add events for when temperature readings are above/below a threshold.                                                                                                                                                         |
+| 2025-12-05 | Initial Thermal Manager component SDD                                                                                                                                                                                         |


### PR DESCRIPTION
# Fix Temperature Threshold Events and Improve Thermal Manager

## Description
* Fixes issue where threshold events would not throttle properly if one sensor was not working. 
* Eliminated global throttle-clear behavior, threshold handling now uses a per-sensor state.
* Created a helper function `evaulateTemperatureThreshold` in `ThermalManager` to reduce duplicated code.

## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Z Tests
- [ ] Manual testing (describe steps)

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
