### PR TITLE
Add local OpenOCD build and Make targets for debug and flashing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ build-mcuboot: submodules zephyr fprime-venv
 
 OPENOCD_DIR ?= $(shell pwd)/tools/openocd
 OPENOCD_REPO ?= https://github.com/raspberrypi/openocd.git
-OPENOCD_REF ?= v0.12.0
+OPENOCD_REF ?= acff23f
 OPENOCD_BIN ?= $(OPENOCD_DIR)/src/openocd
 OPENOCD_JOBS ?= 4
 OPENOCD_FLASH_SPEED ?= 5000

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ OPENOCD_REF ?= v0.12.0
 OPENOCD_BIN ?= $(OPENOCD_DIR)/src/openocd
 OPENOCD_JOBS ?= 4
 OPENOCD_FLASH_SPEED ?= 5000
-OPENOCD_COMMON_FLAGS ?= -s tcl -f interface/cmsis-dap.cfg -f target/rp2350.cfg -c "adapter speed $(OPENOCD_FLASH_SPEED)"
+OPENOCD_COMMON_FLAGS ?= -s $(OPENOCD_DIR)/tcl -f interface/cmsis-dap.cfg -f target/rp2350.cfg -c "adapter speed $(OPENOCD_FLASH_SPEED)"
 
 $(OPENOCD_DIR)/.built:
 	@if [ ! -d "$(OPENOCD_DIR)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -180,27 +180,29 @@ build-mcuboot: submodules zephyr fprime-venv
 
 OPENOCD_DIR ?= $(shell pwd)/tools/openocd
 OPENOCD_REPO ?= https://github.com/raspberrypi/openocd.git
+OPENOCD_REF ?= v0.12.0
 OPENOCD_BIN ?= $(OPENOCD_DIR)/src/openocd
 OPENOCD_JOBS ?= 4
 OPENOCD_FLASH_SPEED ?= 5000
 OPENOCD_COMMON_FLAGS ?= -s tcl -f interface/cmsis-dap.cfg -f target/rp2350.cfg -c "adapter speed $(OPENOCD_FLASH_SPEED)"
 
-.PHONY: openocd
-openocd: ## Download and build a local OpenOCD binary from the Raspberry Pi fork
+$(OPENOCD_DIR)/.built:
 	@if [ ! -d "$(OPENOCD_DIR)" ]; then \
 		git clone "$(OPENOCD_REPO)" "$(OPENOCD_DIR)"; \
 	fi
 	@cd "$(OPENOCD_DIR)" && \
+		git checkout "$(OPENOCD_REF)" || { echo "Failed to checkout $(OPENOCD_REF)"; exit 1; } && \
 		./bootstrap && \
 		./configure --disable-werror --enable-cmsis-dap --enable-cmsis-dap-v2 && \
 		$(MAKE) -j$(OPENOCD_JOBS)
+	@touch "$(OPENOCD_DIR)/.built"
 
 .PHONY: debug
-debug: openocd ## Run OpenOCD against the debug probe and stream board debug output
+debug: $(OPENOCD_DIR)/.built ## Run OpenOCD against the debug probe and stream board debug output
 	@"$(OPENOCD_BIN)" $(OPENOCD_COMMON_FLAGS)
 
 .PHONY: debug-install
-debug-install: openocd ## Flash a file via SWD with OpenOCD. Usage: make debug-install <filename>
+debug-install: $(OPENOCD_DIR)/.built ## Flash a file via SWD with OpenOCD. Usage: make debug-install <filename>
 	@TARGET_FILE="$(firstword $(filter-out $@,$(MAKECMDGOALS)))"; \
 	if [ -z "$$TARGET_FILE" ]; then \
 		echo "Usage: make debug-install <filename>"; \

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,42 @@ build-mcuboot: submodules zephyr fprime-venv
 	mv $(shell pwd)/build/with_mcuboot/zephyr/zephyr.uf2 $(shell pwd)/mcuboot.uf2
 	mv $(shell pwd)/build/mcuboot/zephyr/zephyr.elf $(shell pwd)/mcuboot.elf
 
+##@ Debugging / OpenOCD
+
+OPENOCD_DIR ?= $(shell pwd)/tools/openocd
+OPENOCD_REPO ?= https://github.com/raspberrypi/openocd.git
+OPENOCD_BIN ?= $(OPENOCD_DIR)/src/openocd
+OPENOCD_JOBS ?= 4
+OPENOCD_FLASH_SPEED ?= 5000
+OPENOCD_COMMON_FLAGS ?= -s tcl -f interface/cmsis-dap.cfg -f target/rp2350.cfg -c "adapter speed $(OPENOCD_FLASH_SPEED)"
+
+.PHONY: openocd
+openocd: ## Download and build a local OpenOCD binary from the Raspberry Pi fork
+	@if [ ! -d "$(OPENOCD_DIR)" ]; then \
+		git clone "$(OPENOCD_REPO)" "$(OPENOCD_DIR)"; \
+	fi
+	@cd "$(OPENOCD_DIR)" && \
+		./bootstrap && \
+		./configure --disable-werror --enable-cmsis-dap --enable-cmsis-dap-v2 && \
+		$(MAKE) -j$(OPENOCD_JOBS)
+
+.PHONY: debug
+debug: openocd ## Run OpenOCD against the debug probe and stream board debug output
+	@"$(OPENOCD_BIN)" $(OPENOCD_COMMON_FLAGS)
+
+.PHONY: debug-install
+debug-install: openocd ## Flash a file via SWD with OpenOCD. Usage: make debug-install <filename>
+	@TARGET_FILE="$(firstword $(filter-out $@,$(MAKECMDGOALS)))"; \
+	if [ -z "$$TARGET_FILE" ]; then \
+		echo "Usage: make debug-install <filename>"; \
+		exit 1; \
+	fi; \
+	if [ ! -f "$$TARGET_FILE" ]; then \
+		echo "File not found: $$TARGET_FILE"; \
+		exit 1; \
+	fi; \
+	"$(OPENOCD_BIN)" $(OPENOCD_COMMON_FLAGS) -c "program $$TARGET_FILE verify reset exit"
+
 test-unit: ## Run unit tests
 	cmake -S PROVESFlightControllerReference/test/unit-tests -B build-gtest -DBUILD_TESTING=ON
 	cmake --build build-gtest


### PR DESCRIPTION
### Motivation
- Provide an in-repo OpenOCD binary so Makefile targets can reliably talk to the RP2350 debug probe regardless of host package manager state, following the build steps documented in PR #359 (clone Raspberry Pi OpenOCD fork, `./bootstrap`, `./configure --disable-werror --enable-cmsis-dap --enable-cmsis-dap-v2`, `make -j4`).

### Description
- Add Make variables (`OPENOCD_DIR`, `OPENOCD_REPO`, `OPENOCD_BIN`, `OPENOCD_JOBS`, `OPENOCD_FLASH_SPEED`, `OPENOCD_COMMON_FLAGS`) to centralize in-repo OpenOCD settings and flags. 
- Add `openocd` target that clones the Raspberry Pi OpenOCD fork into `tools/openocd` and builds it with the documented sequence (`./bootstrap`, `./configure --disable-werror --enable-cmsis-dap --enable-cmsis-dap-v2`, `make -j$(OPENOCD_JOBS)`).
- Add `debug` target which runs the repo-local OpenOCD binary with the RP2350 + CMSIS-DAP config and configured adapter speed to stream the board/debug-probe output. 
- Add `debug-install` target implemented as `make debug-install <filename>` which validates the filename and then invokes the local OpenOCD binary with `-c "program <file> verify reset exit"` to flash over SWD.

### Testing
- Ran `make help` to confirm the new targets (`openocd`, `debug`, `debug-install`) are listed and the usage text displays correctly, and this succeeded. 
- Performed a dry-run invocation `make -n debug-install bootable.signed.hex` to exercise the target logic; the run demonstrated the expected clone/build invocation (and failed where the OpenOCD tree was not yet present), which is expected prior to running `make openocd`. 
- Committed the Makefile change and verified repository status with `git status`/`git commit` to ensure the patch was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8cdd5668832681b27886a7f34619)