### PR TITLE
Add pull-up bias to UART0/UART1 RX pinctrl

### DIFF
--- a/boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5-pinctrl.dtsi
+++ b/boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5-pinctrl.dtsi
@@ -19,6 +19,7 @@
 		group2 {
 			pinmux = <UART0_RX_P1>;
 			input-enable;
+			bias-pull-up;
 		};
 	};
 	uart1_default: uart1_default {
@@ -29,6 +30,7 @@
 		group2 {
 			pinmux = <UART1_RX_P5>;
 			input-enable;
+			bias-pull-up;
 		};
 	};
 	spi1_default: spi1_default {


### PR DESCRIPTION
## Summary
UART0_RX (GPIO1) and UART1_RX (GPIO5) were configured input-enable without bias. When the payload connector is unattached, or when the attached payload device is mid-reset during the longer MCUBoot+app boot window, the floating RX pin picks up environmental noise. The PL011 interprets the noise as start bits and asserts RXIM continuously; on uart_irq_rx_enable() during topology setup, the CPU becomes pinned in the RX ISR and the main thread never advances, producing an apparent boot hang that only a hard power cycle clears.

Adding bias-pull-up; idles RX HIGH (UART idle state) when undriven, eliminating the false start bits and the resulting interrupt storm.

Diagnosis confirmed via gdb halt on the live hung CPU: stack pinned in pl011_irq_rx_ready -> serial_cb -> pl011_isr from inside peripheralUartDriver.configure.

## Investigation Summary: Boot Hang After MCUBoot Reflash                                                                                                                                
                                                                                                                                                                                        
###  Symptom
                                                                                                                                                                                        
  After flashing MCUBoot to an RP2350 via Pico Debug Probe + OpenOCD, then flashing the application image, the firmware would intermittently hang during boot. Console output appeared  
  to stop at varying points — most often around the LoRa initialization log lines ([LoRa] TX Power: 23). MCU resets and reflashes did not recover; only multiple hard power cycles
  cleared the condition. The hang manifested only after MCUBoot was the first stage flashed; flashing the app alone did not reproduce it.                                               
                                                                                                                                                                                      
###  Root Cause

  Floating UART RX pin generating an interrupt storm that starved the main thread.                                                                                                      
   
  The board's peripheralUart (PL011 UART0, RX = GPIO 1) is configured in pinctrl with input-enable but without a pull-up bias. When nothing actively drives the line — e.g., the payload
   connector is empty, or the connected payload device is mid-reset during the longer MCUBoot+app boot window — the floating pin picks up environmental noise. That noise is interpreted
   as start bits, populating the PL011 RX FIFO with garbage data and asserting RXIM continuously.                                                                                       
                                                            
  When peripheralUartDriver.configure() runs in setupTopology and calls uart_irq_rx_enable(), the PL011 immediately fires an RX interrupt. The ISR (pl011_isr → serial_cb) drains the   
  FIFO, but the noise refills it before the ISR can return. The CPU is now permanently in interrupt context, the main thread never advances, the rate group ticker (startRateGroups() in
   Main.cpp) never starts, and no further log output is produced.                                                                                                                       
                                                            
  This was definitively confirmed via gdb halt + backtrace on the hung CPU:                                                                                                             
   
  #0 pl011_irq_rx_ready                                              uart_pl011.c:482                                                                                                   
  #1 uart_irq_rx_ready                                               uart_internal.h:397                                                                                                
  #2 Zephyr::ZephyrUartDriver::serial_cb                             ZephyrUartDriver.cpp:77                                                                                            
  #3 pl011_isr                                                       uart_pl011.c:682                                                                                                   
  #4 _isr_wrapper                                                    isr_wrapper.c:80                                                                                                   
  #5 <signal handler called>                                                                                                                                                            
  #6 Zephyr::ZephyrUartDriver::configure                             ZephyrUartDriver.cpp:59                                                                                            
  #7 ReferenceDeployment::setupTopology                              ReferenceDeploymentTopology.cpp:150                                                                                
  #8 main                                                            Main.cpp:131                                                                                                       
                                                                                                                                                                                        
  ### Why MCUBoot Reflash Specifically                                                                                                                                                      
                                                            
  MCUBoot's image-swap and signature-verify on first boot lengthens the time between MCU reset and the application calling uart_irq_rx_enable(). During this longer window, an attached 
  payload device is also resetting and may not yet be driving its TX line, so the FCB's RX line floats. Without the bootloader, app boots fast enough that the payload (or absence of
  one) hasn't shifted state. This explains the "occasional" nature and the MCUBoot-correlation.                                                                                         
                                                            
###  Why Hard Power Cycle Was Needed

  A debug-probe-driven MCU reset only resets the FCB; it does not power-cycle attached peripherals on the payload connector. The payload device that should be driving UART TX continues
   running in whatever state it was in. A full power cycle resets everything, so on the next boot the line is properly driven (or noise patterns are different and don't trigger the
  storm window).                                                                                                                                                                        
                                                            
##  Fix

  boards/bronco_space/proves_flight_control_board_v5/proves_flight_control_board_v5-pinctrl.dtsi — added bias-pull-up; to UART0 RX and UART1 RX pinctrl groups. With the pin idling HIGH
   (UART idle state), no false start bits are detected when the line is undriven.
                                                                                                                                                                                        
 ### Theories Investigated and Ruled Out                       

  The investigation took several wrong turns before landing on the right answer. Documenting them so we don't waste time on them again:                                                 
   
  1. SX1276 chip stuck in bad mode after reflash. Initial hypothesis based on the hang appearing right after the LoRa init log block. Implemented a pre-config reset GPIO toggle in     
  LoRa::start. Did not fix the hang. Granular tracing through lora_config and lora_recv_async confirmed both completed successfully.
    - The reset toggle was kept anyway as defense-in-depth — it makes lora_config more deterministic across MCU resets and is harmless. (lib/fprime-zephyr/.../LoRa.cpp)                
  2. USB CDC ACM TX backpressure. Strongly suspected after observing partial console output ([Os::) and inspecting cdc_acm_poll_out (lib/zephyr-workspace/.../usbd_cdc_acm.c:991), which
   has an infinite k_msleep(1) retry loop when flow_ctrl=true and the ring buffer is full. Ruled out because:                                                                           
    - The board's DT does not set hw-flow-control, so flow_ctrl defaults to false, which causes cdc_acm_poll_out to drop chars on overflow rather than block.                           
    - Test confirmed: a persistent minicom session was actively draining the CDC ACM buffer and the hang still occurred.                                                                
  3. Watchdog LED inactivity as evidence of CPU lockup. The Watchdog component's GPIO toggle is driven by the 1Hz rate group, which only starts when setupTopology returns and          
  startRateGroups() runs the timer cycle loop in Main.cpp. Until setupTopology completes, the LED cannot toggle regardless of cause — so absence of LED activity is necessary but not   
  sufficient evidence of a CPU hang vs. a stuck setup phase. The actual hang location had to be confirmed via gdb attach.                                                               
                                                                                                                                                                                        
##  Secondary Issues Worth Following Up                                                                                                                                                   
   
  - ZephyrUartDriver::serial_cb has an unbounded loop in IRQ context (already flagged with a // TODO: Get rid of the endless loop (in an IRQ handler!). comment at                      
  lib/fprime-zephyr/.../ZephyrUartDriver.cpp:73). The pull-up fix removes the most common trigger, but the underlying vulnerability remains: any sustained data stream on RX still pins
  the CPU in ISR context. Hardening options: cap iterations per ISR call and re-arm via work item, or handle PL011 error interrupts (framing/overrun/break) which currently are         
  unhandled and would cause a similar stuck-pending state.  
  - pl011_irq_update returns 1 unconditionally (lib/zephyr-workspace/.../uart_pl011.c:500). In Zephyr's interrupt-driven UART API, uart_irq_update is supposed to latch pending IRQ
  state for subsequent uart_irq_rx_ready / uart_irq_tx_ready queries. The PL011 driver effectively skips this, which contributes to ISRs re-entering on every register-level            
  reassertion.
  - Submodules are at detached HEAD (lib/fprime-zephyr at 3139971, lib/zephyr-workspace/zephyr at 3568e1b6d5c). The LoRa.cpp pre-config reset edit lives in the fprime-zephyr submodule 
  — it needs a separate commit there and a submodule pointer bump in the main repo, or the change won't survive a fresh clone.                                                          
   
##  Diagnostic Approach Used                                                                                                                                                              
                                                            
  Lessons for similar future investigations:                                                                                                                                            
   
  - Console-based tracing has fundamental limits when the failure mode involves the console itself or starves the printing thread. Multiple hours were spent shifting hang-points by    
  adding/removing log lines, which only obscured the picture.
  - gdb attach via the debug probe is the definitive tool. Attach to the live hung CPU (monitor halt, bt full, thread apply all bt) gives the actual PC and call chain in seconds. This 
  should be the first-line diagnostic for any "hangs at boot" symptom on this hardware, not the last resort.                                                                            
  - The right elf for this project is build-fprime-automatic-zephyr/zephyr/zephyr.elf, not the MCUBoot binary at build/with_mcuboot/zephyr/zephyr.elf.