### PR TITLE
Add make format-filesystem command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,7 +130,6 @@ jobs:
 
         # Reboot before installation to avoid watchdog reset
       - name: Reboot Integration Cube
-        if: env.KORAD_CONTROL == 'true'
         run: |
           ~/korad_control/.venv/bin/python ~/korad_control/korad_control.py -d /dev/ttyPWR --output 0
           sleep 3
@@ -149,7 +148,6 @@ jobs:
 
         # Reboot after installation to ensure power monitor tests work
       - name: Reboot Integration Cube
-        if: env.KORAD_CONTROL == 'true'
         run: |
           ~/korad_control/.venv/bin/python ~/korad_control/korad_control.py -d /dev/ttyPWR --output 0
           sleep 3
@@ -177,6 +175,7 @@ jobs:
           make test-integration
 
       - name: Format Filesystem
+        if: always()
         run: |
           make format-filesystem
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,7 +176,12 @@ jobs:
         run: |
           make test-integration
 
-      - name: Kill GDS
+      - name: Format Filesystem
+        run: |
+          make format-filesystem
+
+      - name: Kill GDS & Power Off Satellite
         if: always()
         run: |
           kill $(cat server.pid)
+          ~/korad_control/.venv/bin/python ~/korad_control/korad_control.py -d /dev/ttyPWR --output 0

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,11 @@ sync-sequence-number: fprime-venv ## Synchronize sequence number between GDS and
 	@echo "Synchronizing sequence number; ensure you have the GDS open."
 	$(UV_RUN) pytest PROVESFlightControllerReference/test/sync_sequence_number.py --deployment build-artifacts/zephyr/fprime-zephyr-deployment
 
+.PHONY: format-filesystem
+format-filesystem: fprime-venv ## Format the filesystem of a connected FC board
+	@echo "Formatting the flight controller's filesystem; ensure you have the GDS open."
+	$(UV_RUN) pytest PROVESFlightControllerReference/test/format_filesystem.py --deployment build-artifacts/zephyr/fprime-zephyr-deployment
+
 .PHONY: clean
 clean: ## Remove all gitignored files
 	git clean -dfX

--- a/PROVESFlightControllerReference/test/format_filesystem.py
+++ b/PROVESFlightControllerReference/test/format_filesystem.py
@@ -28,7 +28,7 @@ def check_gds(fprime_test_api_session: IntegrationTestAPI):
             time.sleep(1)
     assert gds_working
 
-    yield
+    return
 
 
 def test_format_filesystem(fprime_test_api: IntegrationTestAPI):

--- a/PROVESFlightControllerReference/test/format_filesystem.py
+++ b/PROVESFlightControllerReference/test/format_filesystem.py
@@ -1,0 +1,38 @@
+"""
+format_filesystem.py:
+
+This test runs the format command to reset the filesystem if it has gotten into a bad state. You may need to manually restart the satellite after running this command, so use caution.
+"""
+
+import time
+
+import pytest
+from fprime_gds.common.testing_fw.api import IntegrationTestAPI
+from int.common import cmdDispatch, proves_send_and_assert_command
+
+
+@pytest.fixture(scope="session", autouse=True)
+def check_gds(fprime_test_api_session: IntegrationTestAPI):
+    """Fixture to check GDS is running"""
+
+    gds_working = False
+    timeout_time = time.time() + 30
+    while time.time() < timeout_time:
+        try:
+            fprime_test_api_session.send_and_assert_command(
+                command=f"{cmdDispatch}.CMD_NO_OP"
+            )
+            gds_working = True
+            break
+        except Exception:
+            time.sleep(1)
+    assert gds_working
+
+    yield
+
+
+def test_format_filesystem(fprime_test_api: IntegrationTestAPI):
+    """Send command to format the filesystem"""
+    proves_send_and_assert_command(
+        fprime_test_api, "ReferenceDeployment.fsFormat.FORMAT"
+    )

--- a/PROVESFlightControllerReference/test/sync_sequence_number.py
+++ b/PROVESFlightControllerReference/test/sync_sequence_number.py
@@ -31,7 +31,7 @@ def check_gds(fprime_test_api_session: IntegrationTestAPI):
             time.sleep(1)
     assert gds_working
 
-    yield
+    return
 
 
 def test_sync_sequence_number(fprime_test_api: IntegrationTestAPI):


### PR DESCRIPTION
# Add make format-filesystem command

## Description

Adds the `make format-filesystem` command to primarily be used in CI to mitigate filesystem issues. Also shuts off the cube after the tests are done running

## Related Issues/Tickets

<!-- Link any relevant issues, tasks, or user stories (e.g., Closes #123, Fixes #456). -->

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Unit tests
- [x] Integration tests
- [ ] Z Tests
- [ ] Manual testing (describe steps)

## Screenshots / Recordings (if applicable)

<!-- Provide screenshots or screen recordings that demonstrate the changes, especially for UI-related updates. -->

## Checklist

- [ ] Written detailed sdd with requirements, channels, ports, commands, telemetry defined and correctly formatted and spelled
- [ ] Have written relevant integration tests and have documented them in the sdd
- [ ] Have done a code review with
- [ ] Have tested this PR on every supported board with correct board definitions

## Further Notes / Considerations
