### PR TITLE
fix(StartupManager): reject corrupt quiescence file to break boot-loop

### DIFF
--- a/PROVESFlightControllerReference/Components/StartupManager/StartupManager.cpp
+++ b/PROVESFlightControllerReference/Components/StartupManager/StartupManager.cpp
@@ -130,6 +130,13 @@ Fw::Time StartupManager ::update_quiescence_start() {
     Fw::Time time = this->getTime();
     // Open the quiescence start time file and read the current time. On read failure, return the current time.
     StartupManager::Status status = read<Fw::Time, Fw::Time::SERIALIZED_SIZE>(time_file, time);
+    // Reject a corrupt file (e.g. partial flash write leaving 0xFF bytes) whose useconds field is outside
+    // the [0, 999999] contract Fw::Time::set asserts on. Without this, downstream Fw::Time::add panics
+    // in a boot-loop because the bad value persists across reflashes.
+    if (status == StartupManager::SUCCESS && time.getUSeconds() >= 1000000) {
+        time = this->getTime();
+        status = StartupManager::FAILURE;
+    }
     // On read failure, write the current time to the file for future reads. This only happens on read failure because
     // there is a singular quiescence start time for the whole mission.
     if (status != StartupManager::SUCCESS) {


### PR DESCRIPTION
# Pull Request Title (e.g., Feature: Add user authentication)

## Description
A partial flash write to /quiescence_start.bin (e.g. power loss mid-write) can leave a Fw::Time on disk whose useconds field is outside [0, 999999]. On boot, update_quiescence_start reads it back and passes it to the static Fw::Time::add at StartupManager.cpp:189, which trips FW_ASSERT in Fw/Time/Time.cpp:141 (uSeconds < 1999999) followed by line 43 (useconds < 1000000) — observed on hardware with useconds = 0x00FFFFFF (16,777,215), the signature of unprogrammed NOR flash bytes. Watchdog reboot loop, no recovery without external reflash, and the corrupt file persists across firmware versions so any branch hits the same fault.

Validate useconds after read; treat out-of-contract values as a read failure so the existing init-from-getTime + rewrite path takes over.
