### PR TITLE
[TEMP] Skip camera_handler_test.py

### DIFF
--- a/PROVESFlightControllerReference/test/int/camera_handler_test.py
+++ b/PROVESFlightControllerReference/test/int/camera_handler_test.py
@@ -25,6 +25,7 @@ def setup_test(fprime_test_api: IntegrationTestAPI, start_gds):
     time.sleep(5)  # Wait for the camera to power on
 
 
+@pytest.mark.skip(reason="Temporary Skip Due to Lack of Camera in CI Environment")
 def test_01_take_image(fprime_test_api: IntegrationTestAPI, start_gds):
     """Test that we can take an image"""
     start: TimeType = TimeType().set_datetime(


### PR DESCRIPTION
We are temporarily skipping the camera handler test in `main` due to the need to displace the camera from the CI environment. 