### PR TITLE
Remove uart dependency on radio tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -308,7 +308,6 @@ jobs:
       - integration
     needs:
       - build
-      - integration-uart
     steps:
       - uses: actions/checkout@v6
 
@@ -472,20 +471,6 @@ jobs:
           [ -f server.pid ] && kill $(cat server.pid) || true
           [ -f server-rf.pid ] && kill $(cat server-rf.pid) || true
           ~/korad_control/.venv/bin/python ~/korad_control/korad_control.py -d /dev/ttyPWR --output 0
-
-  integration:
-    runs-on: ubuntu-latest
-    needs: [integration-uart, integration-radio]
-    if: always()
-    steps:
-      - name: Check integration results
-        run: |
-          uart="${{ needs.integration-uart.result }}"
-          radio="${{ needs.integration-radio.result }}"
-          echo "integration-uart: $uart"
-          echo "integration-radio: $radio"
-          if [[ "$uart" != "success" && "$uart" != "skipped" ]]; then exit 1; fi
-          if [[ "$radio" != "success" && "$radio" != "skipped" && "$radio" != "cancelled" ]]; then exit 1; fi
 
   yamcs-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR removes the uart dependency on the radio tests.

Benefits:
- We can rerun the radio tests even when the uart tests are failing
- If we ever have a second integration test harness, we can run both tests at the same time

This PR also removes the `integration` step since it doesn't appear to be necessary right now.