### PR TITLE
feat(yamcs): promiscuous TM adapter — accept any spacecraft ID

### DIFF
--- a/.claude/skills/radio-link-testing/OTA-BEST-PRACTICES.md
+++ b/.claude/skills/radio-link-testing/OTA-BEST-PRACTICES.md
@@ -1,0 +1,164 @@
+# OTA uplink best practices
+
+Operational checklist for ground-to-flight firmware/file delivery over the LoRa
+link. Detailed mechanics are in the companion docs; this is the operator's quick
+reference.
+
+See also:
+- [REFERENCE.md](REFERENCE.md) — rig topology, ports, auth, GDS launch
+- [OTA-DROP-PATCHING.md](OTA-DROP-PATCHING.md) — drop recovery loop details
+- [OTA-TIER1-PERFORMANCE.md](OTA-TIER1-PERFORMANCE.md) — throughput numbers, pass capacity
+
+---
+
+## Pre-pass checklist
+
+```bash
+# 1. Confirm exactly ONE GDS holder per port
+lsof /dev/cu.usbmodem21203 | grep -c comm   # must print 1
+lsof /dev/cu.usbmodem21101 | wc -l          # must be 1 (console logger)
+
+# 2. Link alive — GET_SEQ_NUM must land
+bash /tmp/sweep/linkcheck.sh   # or: SPRAY_N=12 pytest ...::test_spray_seq
+
+# 3. Seq in sync — GDS seq file >= flight stored seq
+#    Read flight stored seq from EmitSequenceNumber event, compare to:
+cat Framing/src/sequence_number.bin
+
+# 4. Flight TX disabled (standard uplink mode)
+TX_STATE=DISABLED SPRAY_N=12 pytest ...::test_spray_disable_tx
+```
+
+If the link is dark at step 2, see the **Link-dark diagnostic** section below.
+
+---
+
+## SF/BW selection by elevation
+
+| Elevation | Config | Throughput | Per-pass capacity (5 min) |
+|---|---|---|---|
+| All (default) | SF8 / BW125 | ~258 B/s | ~69 KB |
+| >15° | SF7 / BW125 | ~447 B/s | ~121 KB |
+| >30° | SF7 / BW250 | ~779 B/s | ~210 KB |
+| >60° (overhead, bench-verified) | SF7 / BW500 | ~1299 B/s | ~351 KB |
+
+Switch SF/BW before the pass, not mid-pass. Return to SF8/BW125 after.
+
+**Apply procedure (both sides must match):**
+
+```bash
+# GRC side
+bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.DATA_RATE_PRM_SET SF_7
+bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.BANDWIDTH_TX_PRM_SET BW_250_KHZ
+
+# Flight side — set params, then apply via TRANSMIT toggle
+bash /tmp/fc_cmd.sh ReferenceDeployment.lora.DATA_RATE_PRM_SET SF_7
+bash /tmp/fc_cmd.sh ReferenceDeployment.lora.BANDWIDTH_TX_PRM_SET BW_250_KHZ
+bash /tmp/fc_cmd.sh ReferenceDeployment.lora.BANDWIDTH_RX_PRM_SET BW_250_KHZ
+bash /tmp/fc_cmd.sh ReferenceDeployment.lora.TRANSMIT ENABLED   # must be from DISABLED state
+bash /tmp/fc_cmd.sh ReferenceDeployment.lora.TRANSMIT DISABLED
+bash /tmp/sweep/linkcheck.sh   # verify COUNT > 0 before uploading
+```
+
+**TRANSMIT ENABLED must be sent from DISABLED state.** After a normal
+`ENABLED → DISABLED` cycle the state reaches DISABLED only after `dataIn_handler`
+runs — wait for it (typically 1–2 seconds after the DISABLED command completes).
+If in doubt, run `linkcheck.sh` first; if it passes, the state machine is ready.
+
+---
+
+## File delivery procedure
+
+```bash
+# 1. Copy source — uplinker deletes it on finish
+cp firmware.bin /tmp/ota_src.bin
+
+# 2. Compute truth CRC
+python3 -c "import zlib; print('0x%08X'%(zlib.crc32(open('/tmp/ota_src.bin','rb').read())^0xffffffff))"
+
+# 3. Uplink (TX disabled; timeout > actual transfer time)
+UPLINK_SRC=/tmp/ota_src.bin UPLINK_DEST=//fw.bin UPLINK_TIMEOUT=400 \
+  pytest ...::test_uplink_file
+
+# 4. Verify on-board CRC
+CRC_FILE=//fw.bin SPRAY_N=12 pytest ...::test_calc_crc
+# Console: "CalculateCrcSucceeded : //fw.bin has CRC value 0x..."
+
+# 5. If CRC mismatches — repeat steps 1–4 (re-uplink to the same dest)
+#    Full re-uplink is idempotent: landed chunks are overwritten in place.
+#    At ~0.6 %/frame loss, 1–2 rounds delivers any file intact.
+```
+
+See [OTA-DROP-PATCHING.md](OTA-DROP-PATCHING.md) for the automated `tier1-patch.sh`
+driver which handles multi-part delivery, per-part CRC gating, and reassembly.
+
+---
+
+## Pass capacity planning (ISS orbit, SoCal ground station)
+
+| Image | SF8/BW125 | SF7/BW125 | SF7/BW250 | SF7/BW500 |
+|---|---|---|---|---|
+| 100 KB | 2 passes (~1 day) | 1–2 passes | 1 pass | 1 pass |
+| 350 KB | 5–7 passes (~2 days) | 3–4 passes (~1 day) | 2 passes | 1 pass |
+| 700 KB | 10–13 passes (~2–3 days) | 6–8 passes (~1–2 days) | 3–4 passes (~1 day) | 2 passes |
+
+Assumes ~4–6 passes/day, ~4–7 min usable/pass (ISS-orbit CubeSat, 408 km, 51.6°
+incl., 34°N station). These include ~20% overhead for per-part CRC verify and
+reassembly. BW500 is bench-validated; confirm link margin before using at operating
+range.
+
+---
+
+## Post-pass: return to safe state
+
+```bash
+# Revert to SF8/BW125 (both sides)
+bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.DATA_RATE_PRM_SET SF_8
+bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.BANDWIDTH_TX_PRM_SET BW_125_KHZ
+bash /tmp/fc_cmd.sh  ReferenceDeployment.lora.DATA_RATE_PRM_SET SF_8
+bash /tmp/fc_cmd.sh  ReferenceDeployment.lora.BANDWIDTH_TX_PRM_SET BW_125_KHZ
+bash /tmp/fc_cmd.sh  ReferenceDeployment.lora.BANDWIDTH_RX_PRM_SET BW_125_KHZ
+bash /tmp/fc_cmd.sh  ReferenceDeployment.lora.TRANSMIT ENABLED
+bash /tmp/fc_cmd.sh  ReferenceDeployment.lora.TRANSMIT DISABLED
+```
+
+Flight TX stays DISABLED between passes. SF/BW params are RAM-only — a power-cycle
+reverts to the stored defaults (SF8/BW125). Write params to flash with
+`DATA_RATE_PRM_SAVE` / `BANDWIDTH_TX_PRM_SAVE` / `BANDWIDTH_RX_PRM_SAVE` only when
+intentional.
+
+---
+
+## DON'Ts
+
+| Don't | Why |
+|---|---|
+| Use `lora.CONTINUOUS_WAVE` to apply SF/BW | Wedges the modem (issue #207 fix uncommitted in current binary) — leaves RX dead; requires power-cycle |
+| Trust `FileReceived` as an integrity signal | Logs unconditionally on the END packet, even if frames were dropped |
+| Trust `dropDetector.DETECT_DROPS` | Non-deterministic false positives on this build; use `CalculateCrc` |
+| Spray `AppendFile` | Not idempotent — each send appends a copy; corrupts reassembly |
+| Use chunk size > 200 B | Frame overhead pushes authenticated TC frame over 248 B → `FrameTooLarge` silent drop |
+| Set `UPLINK_TIMEOUT` short | Aborts the transfer mid-stream; file is left holed |
+| Send `TRANSMIT ENABLED` from DISABLING state | No `comStatusOut` fires → modem not reconfigured; power-cycle required |
+
+---
+
+## Link-dark diagnostic
+
+If `linkcheck.sh` returns COUNT=0:
+
+```
+1. Check GDS holders:  lsof /dev/cu.usbmodem21203  → must be exactly 1
+   If >1: pkill -f fprime_gds.executables.comm; pkill -f CustomDataHandlers
+
+2. Flight alive?  bash /tmp/fc_cmd.sh CdhCore.cmdDisp.CMD_NO_OP
+   → "NoOpReceived" on 21101 console = flight alive, LoRa is the problem
+
+3. LoRa modem state:
+   - TRANSMIT ENABLED from DISABLED state → then TRANSMIT DISABLED → re-check
+   - If already sent CONTINUOUS_WAVE: power-cycle required (modem wedged,
+     no software recovery once the ComQueue credit is spent)
+
+4. Seq out of window:  read EmitSequenceNumber from console; advance seq file
+   past it and restart GDS
+```

--- a/.claude/skills/radio-link-testing/OTA-DOWNLINK-PERFORMANCE.md
+++ b/.claude/skills/radio-link-testing/OTA-DOWNLINK-PERFORMANCE.md
@@ -1,0 +1,92 @@
+# OTA Downlink Performance — Measured Results
+
+Measured 2026-06-25 on the bench rig (SF/BW sweep).
+
+**File:** `//tp_asm.bin` (102 400 bytes, CRC `0xb6a19aa4`)
+**Path:** flight LoRa TX → GRC SX1276 RX → USB → bridge GDS → `/tmp/ossf-1/fprime-downlink/`
+**Pacing:** `downlinkDelay.DIVIDER_PRM_SET = 1` (fastest), `telemetryDelay.DIVIDER_PRM_SET = 60` (TM suppressed)
+**Truth gate:** local `zlib.crc32 ^ 0xFFFFFFFF` of received file (no on-board verify needed for downlink)
+
+---
+
+## Throughput table
+
+| Config      | Time (s) | Rate (B/s) | vs SF8 baseline | Notes               |
+|-------------|----------|------------|-----------------|---------------------|
+| SF8/BW125   | 356      | 287.6      | 1.00×           | baseline, no stalls |
+| SF7/BW125   | 261      | 392.3      | 1.36×           | CRC-clean           |
+| SF7/BW250   | 171      | 598.8      | 2.08×           | CRC-clean           |
+| SF7/BW500   | 96       | 1066.6     | 3.71×           | CRC-clean           |
+
+All runs delivered CRC-clean on first attempt.  No GRC stalls observed during any downlink.
+
+---
+
+## Comparison: downlink vs uplink
+
+| Config    | Downlink (B/s) | Uplink (B/s) | DL/UL ratio |
+|-----------|----------------|--------------|-------------|
+| SF8/BW125 | 287.6          | ~258         | 1.12×       |
+| SF7/BW125 | 392.3          | ~447         | 0.88×       |
+| SF7/BW250 | 598.8          | ~779         | 0.77×       |
+| SF7/BW500 | 1066.6         | ~1299        | 0.82×       |
+
+Downlink runs ~15–25 % slower than uplink at the same SF/BW. Likely causes:
+- Flight's `fileDownlink` credit-return chain (`loraRetry → downlinkDelay → framer`) adds one credit-return cycle per packet vs the GDS uplinker's explicit cooldown.
+- Flight `fileDownlink` cycle time = 1 s (from `FileHandlingConfig.fpp`); paced at DIVIDER=1 = 100 ms between frames, but the credit chain still limits burst pacing.
+
+---
+
+## SF/BW switch procedure for downlink
+
+Unlike uplink (where the GRC TX event automatically re-arms RX), downlink requires an explicit GRC modem re-arm because the GRC may not TX between config changes.
+
+```bash
+T=PROVESFlightControllerReference/test/int/bridge_uplink_test.py
+FC_PYTEST=(./fprime-venv/bin/pytest -s -o addopts=""
+  --dictionary build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json
+  --zmq-transport ipc:///tmp/fc-server-in ipc:///tmp/fc-server-out --tts-port 50070)
+
+# 1. Disable flight TX
+CMD="ReferenceDeployment.lora.TRANSMIT" ARGS="DISABLED" REPS=1 "${FC_PYTEST[@]}" $T::test_send_cmd
+
+# 2. Set flight params (SF_7 / BW_250_KHZ / BW_500_KHZ as needed)
+CMD="ReferenceDeployment.lora.DATA_RATE_PRM_SET"   ARGS="SF_7"      "${FC_PYTEST[@]}" $T::test_send_cmd
+CMD="ReferenceDeployment.lora.BANDWIDTH_TX_PRM_SET" ARGS="BW_250_KHZ" "${FC_PYTEST[@]}" $T::test_send_cmd
+CMD="ReferenceDeployment.lora.BANDWIDTH_RX_PRM_SET" ARGS="BW_250_KHZ" "${FC_PYTEST[@]}" $T::test_send_cmd
+
+# 3. Set GRC params + re-arm modem (SET_FREQ calls enableRx() with new params)
+bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.DATA_RATE_PRM_SET    SF_7
+bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.BANDWIDTH_TX_PRM_SET BW_250_KHZ
+bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.BANDWIDTH_RX_PRM_SET BW_250_KHZ
+bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.SET_FREQ 437400000
+
+# 4. Enable flight TX (applies new config)
+CMD="ReferenceDeployment.lora.TRANSMIT" ARGS="ENABLED" REPS=1 "${FC_PYTEST[@]}" $T::test_send_cmd
+
+# 5. Suppress TM and set pacing via bridge GDS (tts 50050)
+TM_DIVIDER=60 SPRAY_N=8 "${PYTEST[@]}" $T::test_suppress_tm
+CMD="ReferenceDeployment.downlinkDelay.DIVIDER_PRM_SET" ARGS="1" REPS=4 "${PYTEST[@]}" $T::test_send_cmd
+
+# 6. Trigger downlink (SPRAY_N=1 critical — spraying causes GRC TX, flight sees START during TX window)
+DL_SRC="//tp_asm.bin" DL_DEST="tp_asm.bin" SPRAY_N=1 "${PYTEST[@]}" $T::test_send_file
+
+# 7. Verify CRC locally (no on-board verify needed)
+python3 -c "import zlib; d=open('/tmp/ossf-1/fprime-downlink/tp_asm.bin','rb').read(); print('crc=0x%08x' % (zlib.crc32(d)^0xffffffff))"
+```
+
+**FC direct GDS requirement:** The `FC_PYTEST` commands require the FC direct GDS running on `/dev/cu.usbmodem21101`.
+This conflicts with `console_logger.py`. Procedure:
+1. Kill console_logger (`kill <pid>` or `pkill -f console_logger.py`)
+2. Launch FC direct GDS: `nohup ./fprime-venv/bin/fprime-gds --uart-device /dev/cu.usbmodem21101 --uart-skip-port-check --gui none --zmq-transport ipc:///tmp/fc-server-in ipc:///tmp/fc-server-out --tts-port 50070 --logs /tmp/sweep/gdslogs/flight-run --dictionary build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json > /tmp/sweep/gdslogs/flight.log 2>&1 &`
+3. After config changes, kill FC GDS and restart console_logger.
+4. Downlink CRC is verified locally — console_logger not needed for downlink.
+
+---
+
+## Known limitations
+
+- **`SPRAY_N=1` for SendFile is mandatory.** SPRAY_N>1 causes the GRC to TX multiple times, and the flight sends the START packet during one of those TX windows. The GDS then sees all subsequent DATA packets as unexpected and discards them.
+- **downlinkDelay cycle time:** `FileHandlingConfig.fpp` `cycleTime=1000ms` means even at DIVIDER=1 the flight paces at the 10 Hz rate group. No further speedup is possible without firmware changes.
+- **Half-duplex:** uplink and downlink cannot run simultaneously without severe contention. Use the file already on the flight FS for downlink sweeps.
+- **GRC stall on CRC error:** If the GRC SX1276 receives a LoRa packet with a CRC error during downlink, it may stall RX. Recovery: `bash /tmp/grc_cmd.sh ReferenceDeployment.uhf.SET_FREQ 437400000`. No stalls were observed in this sweep.

--- a/.claude/skills/radio-link-testing/OTA-DROP-PATCHING.md
+++ b/.claude/skills/radio-link-testing/OTA-DROP-PATCHING.md
@@ -1,0 +1,112 @@
+# OTA drop-patching: reliable file delivery over the lossy LoRa uplink
+
+The LoRa uplink in TX-disabled mode has **no ARQ**, so on large files an occasional
+frame is lost over-air → the on-board file has a hole → the CRC-gated OTA apply
+(`Update.updater.UPDATE_IMAGE_FROM`) would reject it. This is the application-layer
+recovery loop that turns "file arrived with a hole" into "file arrived intact",
+verified on the bench rig 2026-06-20.
+
+Prereqs: drive the rig with the **`radio-link-testing`** skill (launch GDS, sync seq,
+disable flight TX, uplink). Run everything from the flight repo root with the venv pytest
+and the explicit `--dictionary`.
+
+## TL;DR method (deployable today)
+
+```
+loop:
+  1. uplink  <truth> -> //dest.bin           # full file, every round
+  2. verify  CalculateCrc //dest.bin == F'(truth)
+  3. if mismatch -> goto 1 (patch round); else DONE (file is byte-for-byte intact)
+```
+
+Each round is a **full re-uplink to the same destination**. It is idempotent: chunks that
+already landed are overwritten in place with identical data; only the still-missing chunks
+matter. A chunk is wrong only if it was dropped in *every* round. At the measured ~0.6%
+per-chunk loss, a 100 KB / 502-chunk file reaches intact in ~1–2 rounds.
+
+## Why re-uplink doesn't clobber the good chunks (the key property)
+
+`FileUplink` pre-declares the file size on the START packet and writes each DATA packet at
+its absolute `byteOffset`:
+
+- `FileUplink::File::open` opens with `Os::File::OPEN_WRITE`, which on the flight's Zephyr
+  backend = `FS_O_CREATE | FS_O_WRITE` — **no `FS_O_TRUNC`**. Re-opening the same dest does
+  not zero it. (`lib/fprime-zephyr/fprime-zephyr/Os/File.cpp`)
+- Each DATA write does `seek(byteOffset, ABSOLUTE)` then `write(...)`, so chunks land at
+  their true offsets regardless of arrival order, and a re-send overwrites in place.
+  (`lib/fprime/Svc/FileUplink/File.cpp`)
+- A dropped chunk is simply never written, so it reads back as zeros (the file is created
+  sparse/zero-filled up to the highest received offset). NB: chunks dropped at the very
+  *tail* (no later chunk) leave the file short rather than zero-filled — a full re-uplink
+  fixes this because it always re-sends the final chunk.
+
+## Verifying without downlinking — use CalculateCrc, NOT DropDetector
+
+Verdict source = the flight USB console (`/tmp/flight-console-text.log`); grep with `LC_ALL=C`.
+
+**Reliable oracle — `fileManager.CalculateCrc`:**
+```
+CRC_FILE=//dest.bin SPRAY_N=12 "${PYTEST[@]}" ...::test_calc_crc
+# console: "CalculateCrcSucceeded : //dest.bin has CRC value 0x251825dd"
+```
+F´ `CalculateCrc` == **`zlib.crc32(data) ^ 0xFFFFFFFF`** (libcrc CRC-32 without zlib's final
+complement). Verified stable (36/36 identical reads) and correct on 3 files. Compute the
+expected value locally:
+```
+python3 -c "import zlib;print('0x%08X'%(zlib.crc32(open('truth.bin','rb').read())^0xffffffff))"
+```
+If the on-board CRC equals this, the file is byte-for-byte intact.
+
+**Do NOT trust `dropDetector.DETECT_DROPS`.** On this flight build it returns
+**non-deterministic false positives** — three scans of one *proven-intact* file reported
+{99,100,195,468,469}, then {252,253}, then {119,120}. Its read path intermittently returns
+all-zero buffers for non-zero data. Treat any DETECT_DROPS output as untrustworthy until the
+detector is fixed (`lib/fprime-extras/.../DropDetector/DropDetector.cpp::readPacket`).
+
+## Worked demonstration (bench, 2026-06-20)
+
+- File: 100 KB, 502 chunks @ 204 B, all bytes non-zero. GDS `--file-uplink-cooldown 0.4`,
+  flight TX DISABLED, seq synced.
+- **Round 1** uplink → `FileReceived` + `BadChecksum` (computed 0xd9856706 ≠ read 0x6b3ee595):
+  a real over-air drop, file corrupt.
+- **Round 2** = re-uplink the same file to the same `//ota_q1.bin` → `FileReceived`, **no
+  BadChecksum**. On-board `CalculateCrc //ota_q1.bin` = `0x251825dd` = F´(truth) (truth
+  zlib 0xDAE7DA22 ^ 0xFFFFFFFF). **Intact.**
+
+## Operational gotchas (learned the hard way)
+
+- **`UPLINK_TIMEOUT` must exceed the real transfer time.** A 100 KB file takes ~5–7 min at
+  0.4 s cooldown; a short timeout (e.g. 15 s) aborts the transfer mid-stream and the file is
+  left badly holed. Use a generous value (≥400 s for 100 KB).
+- The uplinker **deletes its source file** on finish → always uplink a throwaway `cp`.
+- pytest's `uplink_file_and_await_completion` returns/“passes” well before the file is
+  actually on the board (it tracks the local GDS→GRC handshake, not over-air delivery). Judge
+  completion by `FileReceived //dest.bin` on the flight console, never by the pytest result.
+- Re-sync the GDS seq file on every GDS restart — see the `radio-seq-number-mechanics` memory.
+- Multiple console-logger processes on one USB port collide ("multiple access") and starve
+  each other; keep exactly one per port.
+
+## Composing into an OTA update
+
+The apply half already exists (worktree branch `bridge-cse_019QXe…`,
+`scripts/ota_update.py` + `Update.updater`): upload → `PREPARE_UPDATE` →
+`UPDATE_IMAGE_FROM <file> <crc>` (CRC-gated) → `CONFIGURE_NEXT_BOOT TEST` → power-cycle →
+`CONFIRM_UPDATE`. This drop-patch loop slots in **between upload and PREPARE**: re-uplink +
+CalculateCrc-verify until the image CRC matches, so the CRC-gated apply never aborts on a
+hole.
+
+## Known limitation & future work (bandwidth efficiency)
+
+Every patch round re-sends the **whole** file (~7 min for 100 KB; ~45 min for a 666 KB
+image) even to fix a few chunks. Bandwidth-optimal recovery (re-send only the missing chunks
+at their offsets) needs two things this stack doesn't have yet:
+
+1. **A sparse/offset uplinker.** The stock GDS uplinker reads sequentially from offset 0
+   (`fprime_gds/common/files/uplinker.py`) — it cannot emit only selected chunks. Options:
+   a small custom packet emitter (START with full size + DATA at the missing offsets + END),
+   or strategy **B**: `tools/bin/split-n-seq` to split the file, re-uplink only the dropped
+   parts, and reassemble on-board with `fileManager.AppendFile` (sequence tooling already
+   generated by `split-n-seq`).
+2. **A reliable drop locator** to know which chunks to re-send — blocked on the DropDetector
+   bug above. Until it's fixed, the cheap-to-locate, reliable approach is full re-uplink +
+   CalculateCrc.

--- a/.claude/skills/radio-link-testing/OTA-TIER1-PERFORMANCE.md
+++ b/.claude/skills/radio-link-testing/OTA-TIER1-PERFORMANCE.md
@@ -9,19 +9,30 @@ Method + verification details: [OTA-DROP-PATCHING.md](OTA-DROP-PATCHING.md).
 **Validated end-to-end on the bench (2026-06-20):** 24 KB → 6×4 KB parts, each uploaded
 (16–17 s) and CRC-verified, reassembled, final `//tp_asm.bin` CRC `0x3dd5ffb9` == truth.
 
-## Measured constants (BW125 / CR4-5, cooldown 0.4 s)
+## Measured constants (BW125 / CR4-5, frame-aware bridge, cd=0.0, chunk=200 B)
 
-| Quantity | SF8 (baseline) | SF7 (measured 2026-06-20) |
-|---|---|---|
-| Effective uplink goodput | **256 B/s** (4096 B/16 s, ×6) | **476–477 B/s** (20480 B/42.9–43.0 s, ×2) = **1.86×** |
-| Per 204 B chunk | **0.8 s** (1.25 chunks/s) | **0.42–0.43 s** (2.35 chunks/s) |
-| LoRa frame airtime floor | ~0.69 s/frame (SF8) | ~0.40 s/frame (SF7) |
-| Per-chunk over-air loss | ~0.6 % (3/502) | ~1–2 % observed (1 of 2 runs: 2 drops/101; other run clean) |
-| Usable pass window | ~270 s (4.5 min) | ~270 s |
-| Per-pass clean upload | **~67 KB / ~337 chunks** | **~128 KB / ~630 chunks** |
+All numbers below are with the **frame-aware GRC ByteComBridge** (`c1a941f`, 2026-06-24),
+CRC-verified (fileManager.CalculateCrc == truth).
 
-SF7 measured exactly as predicted (~0.43 s/chunk, ~2×). A dropped run was recovered to a
-clean whole-file CRC by one idempotent re-uplink (drop-patch loop) — see [[ota-drop-patch-loop]].
+| Config | Goodput | vs SF8 | Per-chunk | Pass capacity |
+|---|---|---|---|---|
+| **SF8/BW125** (baseline) | **~258 B/s** | 1× | ~0.78 s | ~69 KB / ~345 chunks |
+| **SF7/BW125** | **~447 B/s** | **1.73×** | ~0.45 s | ~121 KB / ~602 chunks |
+| **SF7/BW250** | **~779 B/s** | **3.02×** | ~0.26 s | ~210 KB / ~1049 chunks |
+| **SF7/BW500** | **~1299 B/s** | **5.03×** | ~0.15 s | ~351 KB / ~1755 chunks |
+
+All measured 2026-06-25 with 4 KB file, chunk=200 B, cd=0.0. CRC PASS ✓ at all configs.
+
+**Old bridge numbers (historical, OLD circular-buffer bridge):** SF8 ~228 B/s (cd=0.9), SF7
+~336 B/s (cd=0.6), bottleneck was GRC drain cadence (~0.6 s/frame), not RF. The frame-aware
+bridge eliminates that bottleneck — throughput is now purely airtime-bound.
+
+**BW250/BW500 require matching on both sides.** Set `BANDWIDTH_TX_PRM_SET` (GRC) and both
+`BANDWIDTH_TX_PRM_SET` + `BANDWIDTH_RX_PRM_SET` (flight). Apply via `TRANSMIT ENABLED →
+DISABLED` from DISABLED state (see [[sf7-switch-apply-mechanics]]).
+
+SF7 (2026-06-20, old bridge, different procedure) measured ~476–477 B/s. The difference is
+measurement method; both are consistent with the airtime model.
 
 **Cooldown is already below the airtime floor**, so throughput is PHY-bound — lowering
 cooldown won't help (it only risks GRC overflow). The lever that moves throughput is the
@@ -34,10 +45,10 @@ reassembly less. So an update can't fit in one pass (100 KB ≈ 6.7 min, 666 KB 
 SF8) — **updates span multiple passes, and the goal is the fewest passes with zero wasted
 re-work.**
 
-| Image | SF8 (~0.8 s/chunk) | SF7 (~0.43 s/chunk, ≈2×) |
-|---|---|---|
-| 100 KB (502 chunks) | ~6.7 min → **2 passes** | ~3.6 min → **1 pass** |
-| 666 KB (3343 chunks) | ~45 min → **~12 passes** | ~24 min → **~7 passes** |
+| Image | SF8/BW125 (~0.78 s/chunk) | SF7/BW125 (~0.45 s/chunk) | SF7/BW250 (~0.26 s/chunk) | SF7/BW500 (~0.15 s/chunk) |
+|---|---|---|---|---|
+| 100 KB (512 chunks) | ~6.7 min → **2 passes** | ~3.8 min → **1 pass** | ~2.2 min → **1 pass** | ~1.3 min → **1 pass** |
+| 666 KB (3410 chunks) | ~44 min → **~10 passes** | ~26 min → **~6 passes** | ~15 min → **~4 passes** | ~8.5 min → **~2 passes** |
 
 (includes ~20 % patch+overhead, rounded up to whole passes)
 
@@ -56,11 +67,13 @@ cost (one `AppendFile` per part) nudges the practical optimum up a little → **
 
 ## Optimization levers, ranked
 
-1. **Spreading factor — biggest lever.** SF8→SF7 ≈ halves airtime → ≈2× throughput → ≈half
-   the passes, for ~2.5 dB of margin. Use **SF7 near closest approach** (high elevation),
-   fall back SF8/SF9 at low elevation. Even if SF7 doubles loss to ~1.2 %, the extra re-send
-   (~+12 % at k=20) is dwarfed by the 2× speedup. `lora.DATA_RATE_PRM_SET SF_7` exists.
-2. **Leave cooldown at 0.4 s** (already airtime-bound); raise only if loss spikes.
+1. **Spreading factor + bandwidth — by far the biggest levers.** With the frame-aware bridge,
+   throughput is purely airtime-bound. SF8→SF7 = 1.73×; SF7+BW250 = 3.02×; SF7+BW500 = 5.03×
+   (all bench-verified, CRC-clean). Use the fastest config the link supports at the current
+   elevation. Apply via `DATA_RATE_PRM_SET` + `BANDWIDTH_*_PRM_SET` then `TRANSMIT ENABLED →
+   DISABLED` (from DISABLED state). BW500 requires high link margin (bench-only until
+   link-budget analysis at operating range; BW250 is a safer intermediate step).
+2. **Cooldown is already eliminated** (frame-aware bridge, cd=0.0 CRC-clean); no further tuning.
 3. **Part size ≈ 20–40 chunks (4–8 KB).** Never pass-sized — one dropped frame then wastes a
    whole pass. Small parts also give ~15 checkpoints per pass.
 4. **Verify with `CalculateCrc`; batch into a CRC manifest for big images.** Per pass you only
@@ -95,7 +108,8 @@ Each part is an independent file, so the update is checkpointed at part granular
 
 ## Bottom line
 
-~4–8 KB parts, SF7 near closest approach (SF8 fallback), `CalculateCrc` verification
-(manifest-batched for firmware), resume by verified-part set: **100 KB in 1–2 passes, a
-666 KB firmware in ~6–12 passes** depending on SF — initial upload is the irreducible floor,
-patch overhead held to ~10–25 %, and no pass's work is ever lost to LOS.
+~4–8 KB parts, highest-SF+BW the link supports (SF7/BW500 on bench = 5× SF8; SF7/BW125 safe
+at low elevations), `CalculateCrc` verification (manifest-batched for firmware), resume by
+verified-part set: **100 KB in 1 pass at SF7/BW250+, a 666 KB firmware in ~2–6 passes
+depending on SF/BW** — initial upload is the irreducible floor, patch overhead held to
+~10–25 %, and no pass's work is ever lost to LOS.

--- a/.claude/skills/radio-link-testing/OTA-TIER1-PERFORMANCE.md
+++ b/.claude/skills/radio-link-testing/OTA-TIER1-PERFORMANCE.md
@@ -9,20 +9,23 @@ Method + verification details: [OTA-DROP-PATCHING.md](OTA-DROP-PATCHING.md).
 **Validated end-to-end on the bench (2026-06-20):** 24 KB → 6×4 KB parts, each uploaded
 (16–17 s) and CRC-verified, reassembled, final `//tp_asm.bin` CRC `0x3dd5ffb9` == truth.
 
-## Measured constants (SF8 / BW125 / CR4-5, cooldown 0.4 s)
+## Measured constants (BW125 / CR4-5, cooldown 0.4 s)
 
-| Quantity | Value | Source |
+| Quantity | SF8 (baseline) | SF7 (measured 2026-06-20) |
 |---|---|---|
-| Effective uplink goodput | **256 B/s** | 4096 B/part in 16 s, ×6 consistent |
-| Per 204 B chunk | **0.8 s** (1.25 chunks/s) | measured |
-| LoRa frame airtime floor (SF8) | ~0.69 s/frame | SF8/BW125/CR4-5 (`LoRaCfg.hpp`, `LoRa.fpp` DATA_RATE=SF_8) |
-| Per-chunk over-air loss | ~0.6 % | 3 drops / 502 chunks baseline |
-| Usable pass window | ~270 s (4.5 min) | given |
-| Per-pass clean upload | **~67 KB / ~337 chunks** | 256 B/s × 270 s |
+| Effective uplink goodput | **256 B/s** (4096 B/16 s, ×6) | **476–477 B/s** (20480 B/42.9–43.0 s, ×2) = **1.86×** |
+| Per 204 B chunk | **0.8 s** (1.25 chunks/s) | **0.42–0.43 s** (2.35 chunks/s) |
+| LoRa frame airtime floor | ~0.69 s/frame (SF8) | ~0.40 s/frame (SF7) |
+| Per-chunk over-air loss | ~0.6 % (3/502) | ~1–2 % observed (1 of 2 runs: 2 drops/101; other run clean) |
+| Usable pass window | ~270 s (4.5 min) | ~270 s |
+| Per-pass clean upload | **~67 KB / ~337 chunks** | **~128 KB / ~630 chunks** |
+
+SF7 measured exactly as predicted (~0.43 s/chunk, ~2×). A dropped run was recovered to a
+clean whole-file CRC by one idempotent re-uplink (drop-patch loop) — see [[ota-drop-patch-loop]].
 
 **Cooldown is already below the airtime floor**, so throughput is PHY-bound — lowering
 cooldown won't help (it only risks GRC overflow). The lever that moves throughput is the
-**spreading factor**.
+**spreading factor** — now verified on the bench, not just modeled.
 
 ## Where the time goes
 

--- a/.claude/skills/radio-link-testing/OTA-TIER1-PERFORMANCE.md
+++ b/.claude/skills/radio-link-testing/OTA-TIER1-PERFORMANCE.md
@@ -1,0 +1,98 @@
+# Tier-1 part-level OTA patch — performance & pass-window optimization
+
+Tier 1 = split the image into independent part-files, upload each, verify each with
+on-board `CalculateCrc`, re-upload only the parts whose CRC is wrong, reassemble with
+`AppendFile`, verify the whole. It uses only working primitives (no sparse uplinker, no
+DropDetector). Driver: `scripts/tier1-patch.sh <source> <num-parts> [max-rounds]`.
+Method + verification details: [OTA-DROP-PATCHING.md](OTA-DROP-PATCHING.md).
+
+**Validated end-to-end on the bench (2026-06-20):** 24 KB → 6×4 KB parts, each uploaded
+(16–17 s) and CRC-verified, reassembled, final `//tp_asm.bin` CRC `0x3dd5ffb9` == truth.
+
+## Measured constants (SF8 / BW125 / CR4-5, cooldown 0.4 s)
+
+| Quantity | Value | Source |
+|---|---|---|
+| Effective uplink goodput | **256 B/s** | 4096 B/part in 16 s, ×6 consistent |
+| Per 204 B chunk | **0.8 s** (1.25 chunks/s) | measured |
+| LoRa frame airtime floor (SF8) | ~0.69 s/frame | SF8/BW125/CR4-5 (`LoRaCfg.hpp`, `LoRa.fpp` DATA_RATE=SF_8) |
+| Per-chunk over-air loss | ~0.6 % | 3 drops / 502 chunks baseline |
+| Usable pass window | ~270 s (4.5 min) | given |
+| Per-pass clean upload | **~67 KB / ~337 chunks** | 256 B/s × 270 s |
+
+**Cooldown is already below the airtime floor**, so throughput is PHY-bound — lowering
+cooldown won't help (it only risks GRC overflow). The lever that moves throughput is the
+**spreading factor**.
+
+## Where the time goes
+
+The initial upload (every byte sent once) dominates; patch re-sends are ~10–25 %, verify and
+reassembly less. So an update can't fit in one pass (100 KB ≈ 6.7 min, 666 KB ≈ 45 min at
+SF8) — **updates span multiple passes, and the goal is the fewest passes with zero wasted
+re-work.**
+
+| Image | SF8 (~0.8 s/chunk) | SF7 (~0.43 s/chunk, ≈2×) |
+|---|---|---|
+| 100 KB (502 chunks) | ~6.7 min → **2 passes** | ~3.6 min → **1 pass** |
+| 666 KB (3343 chunks) | ~45 min → **~12 passes** | ~24 min → **~7 passes** |
+
+(includes ~20 % patch+overhead, rounded up to whole passes)
+
+## Cost model
+
+Total ≈ `C·t_c·(1 + k·p)` + `(C/k)·v` where C = total chunks, k = chunks/part,
+p = per-chunk loss, t_c = 0.8 s, v = per-part overhead (CRC verify + reassembly append).
+
+- `C·t_c` — initial upload (irreducible floor).
+- `C·t_c·k·p` — re-upload waste: a dropped frame forces re-sending its whole **k-chunk part**,
+  so waste grows with part size.
+- `(C/k)·v` — verify + append overhead: grows with part **count**.
+
+Minimizing over k: **k\* = √(v /(t_c·p)) ≈ √(2.5/0.006) ≈ 20 chunks (~4 KB)**. The reassembly
+cost (one `AppendFile` per part) nudges the practical optimum up a little → **4–8 KB parts**.
+
+## Optimization levers, ranked
+
+1. **Spreading factor — biggest lever.** SF8→SF7 ≈ halves airtime → ≈2× throughput → ≈half
+   the passes, for ~2.5 dB of margin. Use **SF7 near closest approach** (high elevation),
+   fall back SF8/SF9 at low elevation. Even if SF7 doubles loss to ~1.2 %, the extra re-send
+   (~+12 % at k=20) is dwarfed by the 2× speedup. `lora.DATA_RATE_PRM_SET SF_7` exists.
+2. **Leave cooldown at 0.4 s** (already airtime-bound); raise only if loss spikes.
+3. **Part size ≈ 20–40 chunks (4–8 KB).** Never pass-sized — one dropped frame then wastes a
+   whole pass. Small parts also give ~15 checkpoints per pass.
+4. **Verify with `CalculateCrc`; batch into a CRC manifest for big images.** Per pass you only
+   verify the ~15 parts you just sent (~30 s, ~10 % of the pass). For the 666 KB image's
+   ~150 parts, a single packed-CRC-manifest downlink beats 150 individual result frames —
+   worth a small FSW addition.
+
+## Resumability (what makes pass windows work)
+
+Each part is an independent file, so the update is checkpointed at part granularity:
+- Ground keeps a **verified-good part set**; never re-upload a verified part.
+- Per pass: uplink burst (flight **TX disabled** — reliable RX) of the next not-good parts
+  until LOS, then a short **TX-enabled** burst to downlink the CRCs. A part interrupted by LOS
+  is just re-sent next pass — no corrupt partial state, because a part is marked good only
+  after its CRC matches (so ≤ one part, ~16 s, is ever wasted at a pass boundary).
+- Reassemble + whole-file CRC + hand to `Update.updater.UPDATE_IMAGE_FROM` only after **all**
+  parts verify — can be its own short final pass.
+
+## Gotchas the bench surfaced
+
+- **`uplink_file_and_await_completion` never returns in TX-disabled mode** (completion needs
+  downlink) — background the kick and judge by `FileReceived` on the console.
+- **`AppendFile` is NOT idempotent** — spraying it appends the part multiple times and
+  corrupts the reassembly. Send it **once** per part and gate on `AppendFileSucceeded`
+  (idempotent commands like `CalculateCrc`/`RemoveFile` are fine to spray). `RemoveFile` the
+  reassembly target before the first append so a retried run doesn't concatenate onto stale
+  data.
+- Compare CRCs **numerically** — the board prints `0x{x}` (no leading zeros); a string compare
+  against a zero-padded value gives false mismatches.
+- Reassembly append-count is a real cost for big files (~N appends); an on-board "concat these
+  parts" command would remove it (future work, overlaps with the Tier-2 sparse path).
+
+## Bottom line
+
+~4–8 KB parts, SF7 near closest approach (SF8 fallback), `CalculateCrc` verification
+(manifest-batched for firmware), resume by verified-part set: **100 KB in 1–2 passes, a
+666 KB firmware in ~6–12 passes** depending on SF — initial upload is the irreducible floor,
+patch overhead held to ~10–25 %, and no pass's work is ever lost to LOS.

--- a/.claude/skills/radio-link-testing/REFERENCE.md
+++ b/.claude/skills/radio-link-testing/REFERENCE.md
@@ -1,0 +1,96 @@
+# Radio-link testing — reference
+
+## Topology
+
+```
+GDS ──USB(21203, raw passthrough)──► GRC dataComDriver ──► byteComBridge ──► LoRa TX
+                                                                                │
+                                                                          (437.4 MHz)
+                                                                                ▼
+flight console (21101) ◄── F´ events   ComCcsdsLora.authenticationRouter ◄── LoRa RX
+                                          │
+                                          ├─► cmdDisp   (commands)
+                                          └─► FileUplink (files)
+```
+
+- **GRC** = Ground Radio Controller (`Open-Source-Space-Foundation/ground-radio-controller`,
+  RP2350/Zephyr/F´). Pure bridge: USB bytes -> LoRa, no reframing.
+- **Flight board** = this repo's deployment. Single USB CDC `cu.usbmodem21101` is
+  BOTH the Zephyr console AND the F´ `comDriver` UART. **No SWD/debug probe** — the
+  console text is the only observability.
+- The CMSIS-DAP probe (`cu.usbmodem102`) is on the **GRC**, not the flight board.
+
+## Ports (numbers drift — re-verify each session)
+
+| Port | Role |
+|---|---|
+| `cu.usbmodem21203` | GRC data port — GDS attaches here |
+| `cu.usbmodem21201` | GRC Zephyr console — GRC-side events (`NoBuffsAvailable`, `UART buffer overrun`) |
+| `cu.usbmodem21101` | Flight console + F´ comDriver — **the verdict** |
+| `cu.usbmodem102` | CMSIS-DAP probe (on the GRC) |
+
+`ls /dev/cu.usbmodem*` to list. Two boards share the bench — do not cross 21101 (flight)
+with the GRC ports. If unsure, `ioreg -l` maps USB product strings to device nodes.
+
+## Reading the verdict
+
+F´ `CdhCore.textLogger` prints every event to the flight USB console as ASCII:
+`[Os::Console] EVENT: (id) (time) SEVERITY: EvtName : msg`. The bytes are interleaved
+with `0x44`-padded binary idle frames, so **always prefix greps with `LC_ALL=C`** and
+match printable runs. Do NOT rely on a GDS frame-decode of 21101 — it misframes.
+
+Key events: `NoOpReceived` (link alive), `OpCodeCompleted`/`OpCodeDispatched` (command ran),
+`EmitSequenceNumber` (GET_SEQ_NUM reply), `FileReceived` (file complete), `BadChecksum`
+(file complete but content gap from a lost frame), `UnexpectedSequenceCount` /
+`PacketOutOfOrder` (dropped frames), `InvalidReceiveMode` (benign — stale transfer cleanup).
+
+## Authentication (the real gate)
+
+Uplink uses `authenticate-space-data-link` framing (`fprime-gds.yml`: frame-size 248,
+file-uplink-chunk-size 204, cooldown 0.400). HMAC key default
+`0x65b32a18e0c63a347b56e8ae6c51358a`. Each packet carries a sequence number; the flight
+accepts seq in `[stored, stored+window(50000)]` and advances `stored=expected+1`.
+
+- **Bypass opcodes** skip HMAC + seq, so they work regardless of sequence: `0x01000000`
+  NO_OP, `0x2200b000` LoRa GET_SEQ_NUM, `0x10065000` TELL_JOKE. Use these as link tests.
+- **Non-bypass** (everything else, incl. `lora.TRANSMIT` `0x1001f009`, and all FILE
+  packets) needs GDS started at/ahead of the flight's current seq.
+- **Sequence source:** GDS reads the starting seq from `Framing/src/sequence_number.bin`
+  (ASCII int) at comm start and auto-increments per frame. Set it by writing that file
+  BEFORE launching GDS. Keep it AHEAD of the board's stored seq (rejected frames bump the
+  file but not the board). Window is huge (50000), so a value comfortably ahead is fine.
+  Read the board's current seq via bypass GET_SEQ_NUM -> `EmitSequenceNumber` on console.
+- The file uplinker synthesizes per-chunk handshakes LOCALLY (loopback), so file packets
+  push regardless of flight TX state; only the *completion telemetry* needs flight TX.
+
+## Why spray, and TX-disabled mode
+
+The link is half-duplex. A single command often misses the flight's RX window, so commands
+are **sprayed** (`SPRAY_N` sends at `SPRAY_GAP` spacing). Once flight TX is DISABLED
+(`lora.TRANSMIT DISABLED`), the flight listens continuously and RX is near-100% reliable —
+this is the user's standard uplink mode. With TX off there is no downlink, so GDS
+`await_completion` times out (expected); judge by `FileReceived` on the console.
+
+## Launching GDS
+
+```bash
+./fprime-venv/bin/fprime-gds --uart-device /dev/cu.usbmodem21203 \
+    --uart-skip-port-check --gui none [--file-uplink-cooldown X] [--file-uplink-chunk-size N]
+```
+Wait for `/tmp/fprime-server-out`. Tear down any stale GDS first (duplicate
+`CustomDataHandlers` on the same `/tmp/fprime-server-{in,out}` ipc cause duplicate/
+out-of-order uplink packets). Use the venv binary — PATH lacks it in non-login shells.
+
+## Gotchas
+
+- `fprime-cli command-send` silently does NOT inject into a running headless GDS (exits 0,
+  sends nothing). Use the pytest `fprime_test_api.send_command(...)` path.
+- The file uplinker DELETES its source file on finish — always uplink a throwaway copy.
+- Reflashing the GRC re-enumerates its USB → kills the 21201/21203 loggers AND breaks the
+  GDS serial link on 21203 (the GDS process may stay alive but go deaf). Restart the
+  console logger(s) and re-verify the link with a spray after any GRC reflash.
+- `LC_ALL=C` before grepping the binary-laden console logs.
+- No `timeout`/`gtimeout` on macOS by default.
+- Loss is dominated by inter-frame SPACING, not RF margin — if frames drop, check the
+  send rate before reaching for TX power. See `[[grc-uplink-crash]]` memory for the
+  full link-tuning history.

--- a/.claude/skills/radio-link-testing/SKILL.md
+++ b/.claude/skills/radio-link-testing/SKILL.md
@@ -60,6 +60,24 @@ only success signal is `FileReceived` on the flight console.
 `PROVESFlightControllerReference/test/int/bridge_uplink_test.py` — tests:
 `test_noop`, `test_get_seq`, `test_spray_seq`, `test_spray_disable_tx`
 (env `TX_STATE`/`SPRAY_N`/`SPRAY_GAP`), `test_enable_tx`, `test_uplink_file`
-(env `UPLINK_SRC`/`UPLINK_DEST`/`UPLINK_TIMEOUT`). Always run with the explicit
-`--dictionary` above and the venv pytest. `fprime-cli command-send` does NOT
-inject into a running headless GDS — only the pytest `send_command` path transmits.
+(env `UPLINK_SRC`/`UPLINK_DEST`/`UPLINK_TIMEOUT`), `test_calc_crc`
+(env `CRC_FILE` → on-board `CalculateCrc`, the reliable read-back oracle),
+`test_detect_drops` (env `DETECT_FILE`/`DETECT_PKT` → `DETECT_DROPS`; **unreliable, see
+OTA doc**). Always run with the explicit `--dictionary` above and the venv pytest.
+`fprime-cli command-send` does NOT inject into a running headless GDS — only the pytest
+`send_command` path transmits.
+
+## Reliable OTA file delivery over the lossy link
+
+To deliver a file intact despite over-air frame loss (and verify it without downlinking),
+see **[OTA-DROP-PATCHING.md](OTA-DROP-PATCHING.md)**: re-uplink the whole file to the same
+dest until `fileManager.CalculateCrc` matches the truth CRC (`= zlib.crc32 ^ 0xFFFFFFFF`).
+`UPLINK_TIMEOUT` must exceed the real transfer time (~7 min for 100 KB @0.4 s) or the
+transfer aborts mid-stream. Do not trust `DETECT_DROPS` (non-deterministic false positives).
+
+For the bandwidth-efficient, pass-window-aware version (split into parts, re-upload only the
+dropped parts, reassemble with `AppendFile`), see
+**[OTA-TIER1-PERFORMANCE.md](OTA-TIER1-PERFORMANCE.md)** and the validated driver
+`scripts/tier1-patch.sh <source> <num-parts>`. Measured uplink ≈ 256 B/s (~0.8 s/chunk,
+SF8); an update spans multiple ~4.5-min passes — dropping to SF7 near closest approach ≈
+doubles throughput. `AppendFile` is NOT idempotent — send it once per part, never sprayed.

--- a/.claude/skills/radio-link-testing/SKILL.md
+++ b/.claude/skills/radio-link-testing/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: radio-link-testing
+description: Test PROVES flight software end-to-end over the LoRa radio link (GDS -> GRC bridge -> flight board) on the bench rig. Use when testing command or file uplink over the radio, exercising the GRC LoRa bridge, validating the GRC-to-flight link, or debugging why uplinked commands/files don't reach the flight board.
+---
+
+# Radio-link testing (GDS -> GRC bridge -> LoRa -> flight)
+
+Drive the flight software over the real LoRa link the way an operator would: a
+headless GDS pushes authenticated commands/files into the **GRC** (Ground Radio
+Controller) over USB; the GRC bridges them to LoRa; the **flight board** receives
+them. The flight board has **no debug probe** — the only verdict is the text it
+prints on its USB console. See [REFERENCE.md](REFERENCE.md) for topology, ports,
+auth internals, and gotchas. Run everything from the flight repo root.
+
+## Rig at a glance
+
+- `cu.usbmodem21203` = GRC data port (GDS attaches here; raw passthrough to LoRa)
+- `cu.usbmodem21201` = GRC Zephyr console (GRC-side events: NoBuffs, overruns)
+- `cu.usbmodem21101` = flight board console **= the verdict** (F´ events as ASCII)
+- Port numbers drift — verify with `ls /dev/cu.usbmodem*`; two boards are on the bench.
+
+## Quick start
+
+```bash
+# 1. Launch headless GDS on the GRC data port (leave running)
+./fprime-venv/bin/fprime-gds --uart-device /dev/cu.usbmodem21203 \
+    --uart-skip-port-check --gui none &        # wait for /tmp/fprime-server-out
+
+# 2. Log the flight console (the only observability) in the background
+./fprime-venv/bin/python3 .claude/skills/radio-link-testing/scripts/console_logger.py \
+    /dev/cu.usbmodem21101 /tmp/flight-console.log &
+
+# 3. Sanity check the link: an authenticated NO_OP must round-trip
+PYTEST=( ./fprime-venv/bin/pytest -s -o addopts=""
+  --dictionary build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json )
+"${PYTEST[@]}" PROVESFlightControllerReference/test/int/bridge_uplink_test.py::test_noop
+# verdict: `NoOpReceived` appears in /tmp/flight-console.log
+```
+
+## Workflow: uplink a file
+
+The user's operational mode is **flight TX disabled** during uplink (avoids
+half-duplex contention). Then GDS gets no downlink, so completion telemetry never
+returns — `uplink_file_and_await_completion` **times out, which is expected**. The
+only success signal is `FileReceived` on the flight console.
+
+1. **Disable flight TX** (spray — single sends miss the half-duplex RX window):
+   `TX_STATE=DISABLED SPRAY_N=12 "${PYTEST[@]}" ...::test_spray_disable_tx`
+   Confirm ~all `OpCodeCompleted` (opcode `0x1001f009`) on the flight console.
+2. **Copy the source first** — the uplinker DELETES its source on finish:
+   `cp myfile.bin /tmp/up.bin`
+3. **Uplink:** `UPLINK_SRC=/tmp/up.bin UPLINK_DEST=//dest.bin UPLINK_TIMEOUT=70 "${PYTEST[@]}" ...::test_uplink_file`
+4. **Read the verdict** on `/tmp/flight-console.log` (prefix greps with `LC_ALL=C`):
+   - `FileReceived : Received file //dest.bin` + no `BadChecksum` = clean win.
+   - `BadChecksum` = file arrived but a frame was lost over-air (no retransmit in TX-off mode).
+   - Check the GRC console for `NoBuffsAvailable` / `UART buffer overrun` = GRC-side drops.
+
+## Test driver
+
+`PROVESFlightControllerReference/test/int/bridge_uplink_test.py` — tests:
+`test_noop`, `test_get_seq`, `test_spray_seq`, `test_spray_disable_tx`
+(env `TX_STATE`/`SPRAY_N`/`SPRAY_GAP`), `test_enable_tx`, `test_uplink_file`
+(env `UPLINK_SRC`/`UPLINK_DEST`/`UPLINK_TIMEOUT`). Always run with the explicit
+`--dictionary` above and the venv pytest. `fprime-cli command-send` does NOT
+inject into a running headless GDS — only the pytest `send_command` path transmits.

--- a/.claude/skills/radio-link-testing/scripts/console_logger.py
+++ b/.claude/skills/radio-link-testing/scripts/console_logger.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Log a board's USB serial console to a text file, extracting printable runs.
+
+The flight/GRC consoles emit F-prime event text interleaved with binary
+(0x44-padded) idle frames. This pulls out the readable >=5-char ASCII runs and
+timestamps them, so a plain `grep` of the output file shows events. The raw bytes
+are also kept alongside for forensics.
+
+Usage:
+    console_logger.py <serial-device> <output-text-log> [baud]
+
+Example:
+    console_logger.py /dev/cu.usbmodem21101 /tmp/flight-console.log
+    grep -a FileReceived /tmp/flight-console.log     # read the verdict
+
+Run in the background; it loops until killed. NOTE: reflashing the GRC
+re-enumerates USB and this process will exit with a read error — restart it.
+"""
+
+import re
+import sys
+import time
+
+import serial  # from the project's fprime-venv
+
+if len(sys.argv) < 3:
+    sys.exit(__doc__)
+
+device = sys.argv[1]
+text_path = sys.argv[2]
+baud = int(sys.argv[3]) if len(sys.argv) > 3 else 115200
+raw_path = text_path + ".raw"
+
+ser = serial.Serial(device, baud, timeout=0.3)
+printable = re.compile(rb"[ -~]{5,}")
+
+with open(raw_path, "ab") as raw, open(text_path, "a", buffering=1) as txt:
+    txt.write(f"\n==== attach {device} {time.strftime('%H:%M:%S')} ====\n")
+    while True:
+        data = ser.read(4096)
+        if not data:
+            continue
+        raw.write(data)
+        raw.flush()
+        for match in printable.findall(bytes(data)):
+            txt.write(
+                f"[{time.strftime('%H:%M:%S')}] {match.decode(errors='replace')}\n"
+            )

--- a/.claude/skills/radio-link-testing/scripts/gen_patch_seq.py
+++ b/.claude/skills/radio-link-testing/scripts/gen_patch_seq.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+gen_patch_seq.py – Saratoga-style hole detection for a received file segment.
+
+Diffs a downloaded segment file against the ground-truth reference to find byte
+ranges that were not received (zero-filled by the GDS at those offsets).  Emits
+an F' command sequence (.seq text) containing one Cancel followed by a
+SendPartial for each hole.  Uplink the compiled binary to the flight, then run
+it with cmdSeq.CS_RUN – the flight autonomously retransmits only the missing
+ranges without any per-hole round-trip from the ground.
+
+Usage:
+    gen_patch_seq.py --dl DL_FILE --ref REF_FILE \\
+                     --flight-src FLIGHT_PATH --dest-name DEST_NAME \\
+                     --seg-offset SEG_OFFSET --seg-len SEG_LEN \\
+                     --out SEQ_FILE [--merge-gap BYTES]
+
+Prints a single line "<n_holes> <total_seq_secs>" to stdout.
+Exit 0 always; caller checks n_holes.
+"""
+
+import argparse
+from pathlib import Path
+
+
+def find_holes(dl_segment: bytes, ref_segment: bytes, merge_gap: int = 256):
+    """Return (offset_in_segment, length) pairs for byte ranges where dl != ref.
+
+    Ranges within merge_gap bytes of each other are merged into one request to
+    reduce the number of SendPartial commands in the sequence.
+    """
+    n = len(ref_segment)
+    holes: list[tuple[int, int]] = []
+    in_hole = False
+    hole_start = 0
+
+    for i in range(n):
+        dl_byte = dl_segment[i] if i < len(dl_segment) else 0
+        differs = dl_byte != ref_segment[i]
+        if differs and not in_hole:
+            hole_start = i
+            in_hole = True
+        elif not differs and in_hole:
+            holes.append((hole_start, i - hole_start))
+            in_hole = False
+    if in_hole:
+        holes.append((hole_start, n - hole_start))
+
+    if not holes or merge_gap <= 0:
+        return holes
+
+    merged: list[list[int]] = [[holes[0][0], holes[0][1]]]
+    for start, length in holes[1:]:
+        prev = merged[-1]
+        if start <= prev[0] + prev[1] + merge_gap:
+            prev[1] = (start + length) - prev[0]
+        else:
+            merged.append([start, length])
+    return [(s, ln) for s, ln in merged]
+
+
+def hold_secs(length: int) -> int:
+    """Conservative per-hole wait in the sequence (seconds).
+
+    Covers: START packet + ceil(length/chunk) DATA packets + END packet +
+    fileDownlink COOLDOWN + sequencer dispatch overhead.  Uses a floor of 20s
+    so tiny holes (single dropped packet) still get adequate time.
+    """
+    # ~200 B/s effective for short ranges (SF8 overhead dominates small payloads)
+    return max(20, (length // 200 + 1) * 3 + 15)
+
+
+def format_rel(secs: int) -> str:
+    h, rem = divmod(secs, 3600)
+    m, s = divmod(rem, 60)
+    return f"R{h:02d}:{m:02d}:{s:02d}"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Generate an F' patch sequence for a CRC-mismatch segment."
+    )
+    ap.add_argument("--dl", required=True, help="Downloaded segment file path")
+    ap.add_argument("--ref", required=True, help="Ground-truth reference file path")
+    ap.add_argument(
+        "--flight-src", required=True, help="Flight FS source path (e.g. //tp_asm.bin)"
+    )
+    ap.add_argument(
+        "--dest-name",
+        required=True,
+        help="GDS destination filename (e.g. tp_asm_dl_1.bin)",
+    )
+    ap.add_argument(
+        "--seg-offset",
+        type=int,
+        required=True,
+        help="Byte offset of segment in the reference file",
+    )
+    ap.add_argument(
+        "--seg-len", type=int, required=True, help="Length of segment in bytes"
+    )
+    ap.add_argument("--out", required=True, help="Output .seq text file path")
+    ap.add_argument(
+        "--merge-gap",
+        type=int,
+        default=256,
+        help="Merge holes within this many bytes (default 256)",
+    )
+    ap.add_argument(
+        "--cancel-delay",
+        type=int,
+        default=3,
+        help="Seconds between Cancel and first SendPartial (default 3)",
+    )
+    args = ap.parse_args()
+
+    ref_data = Path(args.ref).read_bytes()
+    dl_data = Path(args.dl).read_bytes()
+
+    ref_seg = ref_data[args.seg_offset : args.seg_offset + args.seg_len]
+    dl_seg = dl_data[args.seg_offset : args.seg_offset + args.seg_len]
+
+    holes = find_holes(dl_seg, ref_seg, args.merge_gap)
+
+    if not holes:
+        print("0 0")
+        return
+
+    lines = [
+        f"; patch sequence: {args.dest_name} seg offset={args.seg_offset} len={args.seg_len}",
+        f"; {len(holes)} hole(s): "
+        + ", ".join(f"{args.seg_offset + s}+{ln}" for s, ln in holes),
+        "",
+        "R00:00:00 FileHandling.fileDownlink.Cancel",
+    ]
+
+    total_secs = args.cancel_delay
+    prev_len = 0
+    for idx, (seg_start, seg_len) in enumerate(holes):
+        abs_offset = args.seg_offset + seg_start
+        delay = args.cancel_delay if idx == 0 else hold_secs(prev_len)
+        if idx > 0:
+            total_secs += hold_secs(prev_len)
+        lines.append(
+            f"{format_rel(delay)} FileHandling.fileDownlink.SendPartial,"
+            f' "{args.flight_src}", "{args.dest_name}", {abs_offset}, {seg_len}'
+        )
+        prev_len = seg_len
+
+    # Time for the last SendPartial to complete (not a sequence line, but ground must wait)
+    total_secs += hold_secs(prev_len)
+
+    Path(args.out).write_text("\n".join(lines) + "\n")
+    print(f"{len(holes)} {total_secs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/radio-link-testing/scripts/tier1-downlink.sh
+++ b/.claude/skills/radio-link-testing/scripts/tier1-downlink.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# Tier-1 segmented downlink with ground CRC verification.
+#   tier1-downlink.sh <flight-src-file> <num-segments> [max-rounds]
+#   DL_REF=<path>  local ground-truth reference file (required).
+#
+# Downloads <flight-src-file> from the flight FS in N equal byte-range segments
+# using SendPartial. For each segment: verifies the received bytes against the
+# local reference slice CRC, re-downloads mismatches (up to max-rounds). After
+# all segments pass, reassembles on the ground and verifies the whole-file CRC.
+# Logs per-segment timing and throughput.
+#
+# Prerequisites:
+#   - Bridge GDS running on 21203 (1 comm holder on /dev/cu.usbmodem21203)
+#   - console_logger running on 21101 (flight events at /tmp/flight-console-text.log)
+#   - Flight seq in sync with bridge GDS seq file
+set -u
+cd /Users/ossf-1/proves-core-reference
+
+FLIGHT_SRC="${1:?usage: tier1-downlink.sh <flight-src-file> <num-segments> [max-rounds]}"
+N="${2:?num-segments}"
+MAXR="${3:-8}"
+REF="${DL_REF:?DL_REF env var must point to a local ground-truth copy of the flight file}"
+[ -f "$REF" ] || { echo "[dl] ERROR: DL_REF not found: $REF"; exit 1; }
+
+LOG=/tmp/flight-console-text.log
+DL_STORE=/tmp/ossf-1
+DL_DIR="$DL_STORE/fprime-downlink"
+PY=./fprime-venv/bin/python3
+PYTEST=( ./fprime-venv/bin/pytest -s -o addopts=""
+  --dictionary build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json
+  --file-uplink-chunk-size 192 )
+T=PROVESFlightControllerReference/test/int/bridge_uplink_test.py
+
+now(){ date +%s; }
+
+mkdir -p "$DL_DIR"
+
+# Derive a clean output basename: //tp_asm.bin -> tp_asm
+BASE=$( $PY -c "
+import os, sys
+p = sys.argv[1].lstrip('/')
+print(os.path.splitext(os.path.basename(p))[0])
+" "$FLIGHT_SRC" )
+
+# --- pre-compute segment boundaries and slice CRCs from ground reference ---
+TOTAL=$( $PY -c "import os, sys; print(os.path.getsize(sys.argv[1]))" "$REF" )
+SEG_SIZE=$(( TOTAL / N ))
+
+echo "[dl] $FLIGHT_SRC ($TOTAL bytes, ref=$REF) -> $N segments of ~$SEG_SIZE bytes each"
+
+declare -a OFFSET LEN EXP DL_DEST
+for i in $(seq 0 $(( N - 1 ))); do
+  OFFSET[$i]=$(( i * SEG_SIZE ))
+  if [ "$i" -lt $(( N - 1 )) ]; then
+    LEN[$i]=$SEG_SIZE
+  else
+    LEN[$i]=$(( TOTAL - OFFSET[$i] ))
+  fi
+  EXP[$i]=$( $PY -c "
+import zlib, sys
+d = open(sys.argv[1], 'rb').read()
+start, end = int(sys.argv[2]), int(sys.argv[3])
+print('0x%08x' % (zlib.crc32(d[start:end]) ^ 0xFFFFFFFF))
+" "$REF" "${OFFSET[$i]}" "$(( OFFSET[$i] + LEN[$i] ))" )
+  DL_DEST[$i]="${BASE}_dl_${i}.bin"
+  echo "[dl]   seg_$i  offset=${OFFSET[$i]}  len=${LEN[$i]}  expected=${EXP[$i]}  dest=${DL_DEST[$i]}"
+done
+
+# --- rig health check ---
+echo "[dl] === rig health check ==="
+bridge_holders=$( lsof /dev/cu.usbmodem21203 2>/dev/null | grep -vc "^COMMAND" || true )
+if [ "$bridge_holders" != "1" ]; then
+  echo "[dl] ERROR: bridge port (21203) should have exactly 1 holder, got $bridge_holders"
+  echo "[dl]   Fix: pkill -f fprime_gds.executables.comm && bash /tmp/sweep/start_all_gds.sh"
+  exit 1
+fi
+echo "[dl]   bridge comm OK ($bridge_holders holder on /dev/cu.usbmodem21203)"
+
+# --- verify a received segment against ground truth ---
+# GDS writes bytes at their absolute source-file offset (SendPartial semantics):
+# seg_i file has OFFSET[i] zero bytes prepended, then LEN[i] bytes of real data.
+# We CRC the slice [OFFSET[i] : OFFSET[i]+LEN[i]] and require file >= that size.
+verify_seg(){ # idx -> 0 ok / 1 mismatch or missing
+  local i="$1" path="$DL_DIR/${DL_DEST[$i]}"
+  if [ ! -f "$path" ]; then
+    echo "[dl]   verify seg_$i MISSING ($path)"; return 1
+  fi
+  local got_size got_crc min_size
+  got_size=$( $PY -c "import os, sys; print(os.path.getsize(sys.argv[1]))" "$path" )
+  min_size=$(( OFFSET[$i] + LEN[$i] ))
+  got_crc=$( $PY -c "
+import zlib, sys
+d = open(sys.argv[1], 'rb').read()
+start, end = int(sys.argv[2]), int(sys.argv[2]) + int(sys.argv[3])
+print('0x%08x' % (zlib.crc32(d[start:end]) ^ 0xFFFFFFFF))
+" "$path" "${OFFSET[$i]}" "${LEN[$i]}" )
+  if [ "$got_size" -ge "$min_size" ] && [ "$got_crc" = "${EXP[$i]}" ]; then
+    echo "[dl]   verify seg_$i OK  size=$got_size (>=min $min_size)  crc=$got_crc"
+    return 0
+  else
+    echo "[dl]   verify seg_$i MISMATCH  size=$got_size/<$min_size  crc=$got_crc/${EXP[$i]}"
+    return 1
+  fi
+}
+
+# --- downlink one segment ---
+downlink_seg(){ # idx
+  local i="$1" t0 path="$DL_DIR/${DL_DEST[$i]}"
+  t0=$(now)
+  echo "[dl]   seg_$i: ${FLIGHT_SRC}[${OFFSET[$i]}:$(( OFFSET[$i]+LEN[$i] ))] -> ${DL_DEST[$i]}"
+  # Cancel any lingering in-progress downlink from the previous segment
+  SPRAY_N=4 "${PYTEST[@]}" "$T::test_cancel_downlink" >/dev/null 2>&1
+  sleep 1
+  # Remove stale or partial file so await_downlink doesn't see old data as settled
+  rm -f "$path"
+  # SPRAY_N=1 is mandatory: higher values cause the GRC to TX during the spray,
+  # opening the half-duplex RX window so the flight sends START into that window
+  # and the GDS discards all subsequent DATA packets as unexpected.
+  DL_SRC="$FLIGHT_SRC" DL_DEST="${DL_DEST[$i]}" \
+    DL_OFFSET="${OFFSET[$i]}" DL_LENGTH="${LEN[$i]}" \
+    SPRAY_N=1 "${PYTEST[@]}" "$T::test_send_partial" >/dev/null 2>&1
+  # Poll until the file is stable (stops growing for 3 s) or WATCH_SECS expires
+  DL_DEST="${DL_DEST[$i]}" DL_STORAGE="$DL_STORE" WATCH_SECS=180 \
+    "${PYTEST[@]}" "$T::test_await_downlink"
+  echo "[dl]   seg_$i complete in $(( $(now)-t0 ))s"
+}
+
+GRAND0=$(now)
+
+# --- enable flight TX and suppress competing TM ---
+echo "[dl] === enabling flight TX ==="
+TM_DIVIDER=60 SPRAY_N=8 "${PYTEST[@]}" "$T::test_suppress_tm" >/dev/null 2>&1
+CMD="ReferenceDeployment.downlinkDelay.DIVIDER_PRM_SET" ARGS="1" REPS=4 GAP=0.2 \
+  "${PYTEST[@]}" "$T::test_send_cmd" >/dev/null 2>&1
+TX_STATE=ENABLED SPRAY_N=12 "${PYTEST[@]}" "$T::test_spray_disable_tx" >/dev/null 2>&1
+echo "[dl]   TX enabled; pausing 10s for first APID-4 TM packet ..."
+sleep 10
+
+# --- round loop: download all segments, re-download any that fail CRC ---
+declare -a NEED; for i in $(seq 0 $(( N - 1 ))); do NEED[$i]=1; done
+for round in $(seq 0 "$MAXR"); do
+  todo=()
+  for i in $(seq 0 $(( N - 1 ))); do [ "${NEED[$i]}" = 1 ] && todo+=("$i"); done
+  [ "${#todo[@]}" -eq 0 ] && break
+  echo "[dl] === round $round: ${#todo[@]} segment(s) to (re)download: ${todo[*]} ==="
+  # Re-enable TX at start of each round in case flight rebooted (TX defaults to DISABLED)
+  TX_STATE=ENABLED SPRAY_N=12 "${PYTEST[@]}" "$T::test_spray_disable_tx" >/dev/null 2>&1
+  for i in "${todo[@]}"; do downlink_seg "$i"; done
+  for i in "${todo[@]}"; do verify_seg "$i" && NEED[$i]=0; done
+done
+
+# --- disable TX ---
+echo "[dl] === disabling flight TX ==="
+TX_STATE=DISABLED SPRAY_N=12 "${PYTEST[@]}" "$T::test_spray_disable_tx" >/dev/null 2>&1
+
+# --- report remaining failures ---
+remaining=0
+for i in $(seq 0 $(( N - 1 ))); do [ "${NEED[$i]}" = 1 ] && remaining=$(( remaining + 1 )); done
+echo "[dl] segments done; $remaining still bad after $(( MAXR + 1 )) rounds; elapsed=$(( $(now)-GRAND0 ))s"
+[ "$remaining" -ne 0 ] && { echo "[dl] ABORT: $remaining segment(s) unverified — inspect above"; exit 1; }
+
+# --- reassemble on the ground ---
+# Each seg_i file has OFFSET[i] zero bytes then LEN[i] bytes of real data.
+# Extract the real slice from each file and concatenate in order.
+OUT="$DL_DIR/${BASE}_reassembled.bin"
+echo "[dl] === reassembling into $OUT ==="
+tasm=$(now)
+rm -f "$OUT"
+for i in $(seq 0 $(( N - 1 ))); do
+  $PY -c "
+import sys
+d = open(sys.argv[1], 'rb').read()
+start, end = int(sys.argv[2]), int(sys.argv[2]) + int(sys.argv[3])
+sys.stdout.buffer.write(d[start:end])
+" "$DL_DIR/${DL_DEST[$i]}" "${OFFSET[$i]}" "${LEN[$i]}" >> "$OUT"
+done
+echo "[dl]   reassembly done in $(( $(now)-tasm ))s"
+
+# --- verify whole reassembled file ---
+got_whole=$( $PY -c "
+import zlib, sys
+d = open(sys.argv[1], 'rb').read()
+print('0x%08x' % (zlib.crc32(d) ^ 0xFFFFFFFF))
+" "$OUT" )
+exp_whole=$( $PY -c "
+import zlib, sys
+d = open(sys.argv[1], 'rb').read()
+print('0x%08x' % (zlib.crc32(d) ^ 0xFFFFFFFF))
+" "$REF" )
+echo "[dl] FINAL $OUT  crc=$got_whole  expected=$exp_whole  total=$(( $(now)-GRAND0 ))s"
+if [ "$got_whole" = "$exp_whole" ]; then
+  echo "[dl] *** DOWNLOAD INTACT ***"
+else
+  echo "[dl] *** FINAL MISMATCH — reassembled file corrupt ***"
+  exit 1
+fi

--- a/.claude/skills/radio-link-testing/scripts/tier1-downlink.sh
+++ b/.claude/skills/radio-link-testing/scripts/tier1-downlink.sh
@@ -9,6 +9,13 @@
 # all segments pass, reassembles on the ground and verifies the whole-file CRC.
 # Logs per-segment timing and throughput.
 #
+# Saratoga-style patch: when a segment download completes at full size but fails
+# CRC, the script detects which byte ranges were dropped (diff vs reference),
+# generates an F' command sequence with one SendPartial per hole, uplinks it to
+# the flight, and runs it via cmdSeq.CS_RUN.  The flight retransmits only the
+# missing ranges autonomously.  This replaces a full 34KB re-download (~157s)
+# with a small sequence uplink + targeted patch (~60-90s for 2-5 drops).
+#
 # Prerequisites:
 #   - Bridge GDS running on 21203 (1 comm holder on /dev/cu.usbmodem21203)
 #   - console_logger running on 21101 (flight events at /tmp/flight-console-text.log)
@@ -25,11 +32,16 @@ REF="${DL_REF:?DL_REF env var must point to a local ground-truth copy of the fli
 LOG=/tmp/flight-console-text.log
 DL_STORE=/tmp/ossf-1
 DL_DIR="$DL_STORE/fprime-downlink"
+DICT=build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json
 PY=./fprime-venv/bin/python3
+SEQGEN=./fprime-venv/bin/fprime-seqgen
 PYTEST=( ./fprime-venv/bin/pytest -s -o addopts=""
-  --dictionary build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json
+  --dictionary "$DICT"
   --file-uplink-chunk-size 192 )
 T=PROVESFlightControllerReference/test/int/bridge_uplink_test.py
+PATCH_SEQ_GEN=.claude/skills/radio-link-testing/scripts/gen_patch_seq.py
+PATCH_SEQ=/tmp/ossf-dl-patch.seq
+PATCH_BIN=/tmp/ossf-dl-patch.bin
 
 now(){ date +%s; }
 
@@ -125,6 +137,70 @@ downlink_seg(){ # idx
   echo "[dl]   seg_$i complete in $(( $(now)-t0 ))s"
 }
 
+# --- Saratoga-style patch via on-board sequence ---
+# Called only when the segment file is full-size but CRC is wrong.
+# Detects dropped-packet holes vs the reference, generates an F' .seq, uplinks
+# it, and fires CS_RUN so the flight retransmits only the missing ranges.
+patch_via_sequence(){ # idx
+  local i="$1" path="$DL_DIR/${DL_DEST[$i]}"
+  local t0; t0=$(now)
+
+  # Generate patch sequence text
+  rm -f "$PATCH_SEQ" "$PATCH_BIN"
+  local result
+  result=$( $PY "$PATCH_SEQ_GEN" \
+    --dl "$path" \
+    --ref "$REF" \
+    --flight-src "$FLIGHT_SRC" \
+    --dest-name "${DL_DEST[$i]}" \
+    --seg-offset "${OFFSET[$i]}" \
+    --seg-len    "${LEN[$i]}" \
+    --out "$PATCH_SEQ" ) || { echo "[dl]   patch: gen_patch_seq failed; falling back to full re-download"; downlink_seg "$i"; return; }
+
+  local n_holes seq_secs
+  n_holes=$(echo "$result" | awk '{print $1}')
+  seq_secs=$(echo "$result" | awk '{print $2}')
+
+  if [ "$n_holes" -eq 0 ]; then
+    echo "[dl]   patch: 0 holes found (unexpected CRC mismatch); falling back to full re-download"
+    downlink_seg "$i"
+    return
+  fi
+
+  echo "[dl]   patch seg_$i: $n_holes hole(s); sequence will take ~${seq_secs}s"
+  cat "$PATCH_SEQ"
+
+  # Compile sequence text -> binary
+  "$SEQGEN" --dictionary "$DICT" "$PATCH_SEQ" "$PATCH_BIN" >/dev/null 2>&1 \
+    || { echo "[dl]   patch: seqgen compile failed; falling back to full re-download"; downlink_seg "$i"; return; }
+  echo "[dl]   patch: compiled $(wc -c < "$PATCH_BIN") byte sequence binary"
+
+  # Uplink sequence binary to flight (TX disabled to avoid half-duplex contention).
+  # The .seq file is tiny (<300 B, usually 1-2 uplink chunks); UPLINK_TIMEOUT=10 is
+  # enough for the actual transfer — the function times out waiting for FileComplete
+  # TM (which needs TX on), but the bytes are already on flight by then.
+  cp "$PATCH_BIN" "${PATCH_BIN}.up"
+  TX_STATE=DISABLED SPRAY_N=12 "${PYTEST[@]}" "$T::test_spray_disable_tx" >/dev/null 2>&1
+  UPLINK_SRC="${PATCH_BIN}.up" UPLINK_DEST="//patch.seq" UPLINK_TIMEOUT=10 \
+    "${PYTEST[@]}" "$T::test_uplink_file" >/dev/null 2>&1
+  echo "[dl]   patch: sequence uplinked to //patch.seq (expect FileReceived on console)"
+
+  # Re-enable TX, run the patch sequence on-board
+  TX_STATE=ENABLED SPRAY_N=12 "${PYTEST[@]}" "$T::test_spray_disable_tx" >/dev/null 2>&1
+  sleep 5  # Allow first APID-4 TM packet to confirm TX is up
+
+  # CS_RUN with NO_BLOCK; spray 4x so the command survives LoRa uplink loss
+  CMD="ReferenceDeployment.cmdSeq.CS_RUN" ARGS="//patch.seq,NO_BLOCK" REPS=4 GAP=0.5 \
+    "${PYTEST[@]}" "$T::test_send_cmd" >/dev/null 2>&1
+  echo "[dl]   patch: CS_RUN issued; sleeping ${seq_secs}s for sequence to complete ..."
+
+  # Sleep for the calculated sequence duration (computed by gen_patch_seq.py) plus margin
+  local wait=$(( seq_secs + 60 ))
+  sleep "$wait"
+
+  echo "[dl]   patch seg_$i done in $(( $(now)-t0 ))s (sequence ${seq_secs}s + ${wait}s wait)"
+}
+
 GRAND0=$(now)
 
 # --- enable flight TX and suppress competing TM ---
@@ -137,15 +213,35 @@ echo "[dl]   TX enabled; pausing 10s for first APID-4 TM packet ..."
 sleep 10
 
 # --- round loop: download all segments, re-download any that fail CRC ---
+# Classify each pending segment before acting:
+#   full-size but wrong CRC => Saratoga patch (upload targeted sequence, run on-board)
+#   missing or truncated    => full re-download via downlink_seg
+is_full_size(){ # idx -> 0 if file exists and size >= min_size, else 1
+  local i="$1" path="$DL_DIR/${DL_DEST[$i]}"
+  [ -f "$path" ] || return 1
+  local got_size min_size
+  got_size=$( $PY -c "import os,sys; print(os.path.getsize(sys.argv[1]))" "$path" )
+  min_size=$(( OFFSET[$i] + LEN[$i] ))
+  [ "$got_size" -ge "$min_size" ]
+}
+
 declare -a NEED; for i in $(seq 0 $(( N - 1 ))); do NEED[$i]=1; done
 for round in $(seq 0 "$MAXR"); do
   todo=()
   for i in $(seq 0 $(( N - 1 ))); do [ "${NEED[$i]}" = 1 ] && todo+=("$i"); done
   [ "${#todo[@]}" -eq 0 ] && break
-  echo "[dl] === round $round: ${#todo[@]} segment(s) to (re)download: ${todo[*]} ==="
+  echo "[dl] === round $round: ${#todo[@]} segment(s) to process: ${todo[*]} ==="
   # Re-enable TX at start of each round in case flight rebooted (TX defaults to DISABLED)
   TX_STATE=ENABLED SPRAY_N=12 "${PYTEST[@]}" "$T::test_spray_disable_tx" >/dev/null 2>&1
-  for i in "${todo[@]}"; do downlink_seg "$i"; done
+  for i in "${todo[@]}"; do
+    if is_full_size "$i"; then
+      echo "[dl]   seg_$i: full-size file present, trying Saratoga patch"
+      patch_via_sequence "$i"
+    else
+      echo "[dl]   seg_$i: file missing or truncated, full re-download"
+      downlink_seg "$i"
+    fi
+  done
   for i in "${todo[@]}"; do verify_seg "$i" && NEED[$i]=0; done
 done
 

--- a/.claude/skills/radio-link-testing/scripts/tier1-patch.sh
+++ b/.claude/skills/radio-link-testing/scripts/tier1-patch.sh
@@ -14,7 +14,8 @@ LOG=/tmp/flight-console-text.log
 WORK=/tmp/tier1_parts; rm -rf "$WORK"; mkdir -p "$WORK"
 PY=./fprime-venv/bin/python3
 PYTEST=( ./fprime-venv/bin/pytest -s -o addopts=""
-  --dictionary build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json )
+  --dictionary build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json
+  --file-uplink-chunk-size 192 )
 T=PROVESFlightControllerReference/test/int/bridge_uplink_test.py
 
 fcrc(){ $PY -c "import zlib,sys;print('0x%08x'%(zlib.crc32(open(sys.argv[1],'rb').read())^0xffffffff))" "$1"; }
@@ -75,10 +76,8 @@ tasm=$(now)
 for i in "${!parts[@]}"; do
   mark=$(wc -l <"$LOG")
   # AppendFile is NOT idempotent -> send ONCE, confirm AppendFileSucceeded (retry only if not seen)
-  local tries
   for tries in 1 2 3; do
     APPEND_SRC="${DEST[$i]}" APPEND_TGT="$ASM" SPRAY_N=1 "${PYTEST[@]}" "$T::test_append_file" >/dev/null 2>&1
-    local s2
     for s2 in $(seq 1 8); do
       LC_ALL=C tail -n +"$((mark+1))" "$LOG" | grep -aq "AppendFileSucceeded" && break 2
       sleep 2

--- a/.claude/skills/radio-link-testing/scripts/tier1-patch.sh
+++ b/.claude/skills/radio-link-testing/scripts/tier1-patch.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Tier-1 part-level OTA patch loop.
+#   tier1.sh <source-file> <num-parts> [max-rounds]
+# Splits <source> into N parts, uploads each to //tp_<i>.bin, verifies each with
+# on-board CalculateCrc (== zlib.crc32 ^ 0xFFFFFFFF), re-uploads only mismatched
+# parts, reassembles with AppendFile, and verifies the whole file. Logs timings.
+# Verdict source = /tmp/flight-console-text.log (flight USB console).
+set -u
+cd /Users/ossf-1/proves-core-reference
+SRC="${1:?usage: tier1.sh <source> <num-parts> [max-rounds]}"
+N="${2:?num-parts}"
+MAXR="${3:-3}"
+LOG=/tmp/flight-console-text.log
+WORK=/tmp/tier1_parts; rm -rf "$WORK"; mkdir -p "$WORK"
+PY=./fprime-venv/bin/python3
+PYTEST=( ./fprime-venv/bin/pytest -s -o addopts=""
+  --dictionary build-artifacts/zephyr/fprime-zephyr-deployment/dict/ReferenceDeploymentTopologyDictionary.json )
+T=PROVESFlightControllerReference/test/int/bridge_uplink_test.py
+
+fcrc(){ $PY -c "import zlib,sys;print('0x%08x'%(zlib.crc32(open(sys.argv[1],'rb').read())^0xffffffff))" "$1"; }
+now(){ date +%s; }
+
+# --- split locally into N parts, record expected CRCs ---
+split -d -n "$N" "$SRC" "$WORK/p_" || exit 1
+parts=( "$WORK"/p_* )
+echo "[tier1] $SRC -> ${#parts[@]} parts ($(wc -c <"$SRC") bytes); whole F'CRC=$(fcrc "$SRC")"
+declare -a EXP DEST
+for i in "${!parts[@]}"; do EXP[$i]=$(fcrc "${parts[$i]}"); DEST[$i]="//tp_${i}.bin"; done
+
+# --- upload + verify a single part; sets global VERIFY_OK ---
+upload_part(){ # idx  -- kick uplink in bg (await never returns in TX-off mode), poll console
+  local i="$1" dst="${DEST[$i]}" src="${parts[$i]}" mark t0 pid s ok=0
+  cp "$src" "/tmp/tier1_up_${i}.bin"
+  mark=$(wc -l <"$LOG"); t0=$(now)
+  UPLINK_SRC="/tmp/tier1_up_${i}.bin" UPLINK_DEST="$dst" UPLINK_TIMEOUT=180 \
+    "${PYTEST[@]}" "$T::test_uplink_file" >/dev/null 2>&1 &
+  pid=$!
+  for s in $(seq 1 90); do
+    if LC_ALL=C tail -n +"$((mark+1))" "$LOG" | grep -aq "FileReceived : Received file $dst"; then ok=1; break; fi
+    sleep 2
+  done
+  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  if [ "$ok" = 1 ]; then echo "[tier1]   uploaded $dst in $(( $(now)-t0 ))s ($(wc -c <"$src") bytes)"
+  else echo "[tier1]   WARN $dst no FileReceived in $(( $(now)-t0 ))s"; fi
+}
+verify_part(){ # idx -> 0 ok / 1 mismatch
+  local i="$1" dst="${DEST[$i]}" mark got base
+  base=$(basename "$dst"); mark=$(wc -l <"$LOG")
+  CRC_FILE="$dst" SPRAY_N=10 SPRAY_GAP=0.3 "${PYTEST[@]}" "$T::test_calc_crc" >/dev/null 2>&1
+  sleep 1
+  got=$(LC_ALL=C tail -n +"$((mark+1))" "$LOG" | LC_ALL=C grep -aoE "$base has CRC value 0x[0-9a-fA-F]+" | tail -1 | grep -aoE "0x[0-9a-fA-F]+")
+  if [ -n "$got" ] && [ "$((got))" -eq "$((EXP[$i]))" ]; then echo "[tier1]   verify $dst OK ($got)"; return 0
+  else echo "[tier1]   verify $dst MISMATCH got=${got:-none} exp=${EXP[$i]}"; return 1; fi
+}
+
+GRAND0=$(now)
+# --- round 0: upload all, then verify all; subsequent rounds re-upload mismatches ---
+declare -a NEED; for i in "${!parts[@]}"; do NEED[$i]=1; done
+for round in $(seq 0 "$MAXR"); do
+  todo=(); for i in "${!parts[@]}"; do [ "${NEED[$i]}" = 1 ] && todo+=("$i"); done
+  [ "${#todo[@]}" -eq 0 ] && break
+  echo "[tier1] === round $round: ${#todo[@]} part(s) to (re)upload: ${todo[*]} ==="
+  for i in "${todo[@]}"; do upload_part "$i"; done
+  for i in "${todo[@]}"; do verify_part "$i" && NEED[$i]=0; done
+done
+remaining=0; for i in "${!parts[@]}"; do [ "${NEED[$i]}" = 1 ] && remaining=$((remaining+1)); done
+echo "[tier1] parts verified; $remaining still bad after $((MAXR+1)) rounds; deliver-time=$(( $(now)-GRAND0 ))s"
+[ "$remaining" -ne 0 ] && { echo "[tier1] ABORT: parts still bad"; exit 1; }
+
+# --- reassemble in order: clear target, append each part ---
+ASM=//tp_asm.bin
+echo "[tier1] === reassembling -> $ASM ==="
+RM_FILE="$ASM" SPRAY_N=8 "${PYTEST[@]}" "$T::test_remove_file" >/dev/null 2>&1; sleep 1
+tasm=$(now)
+for i in "${!parts[@]}"; do
+  mark=$(wc -l <"$LOG")
+  # AppendFile is NOT idempotent -> send ONCE, confirm AppendFileSucceeded (retry only if not seen)
+  local tries
+  for tries in 1 2 3; do
+    APPEND_SRC="${DEST[$i]}" APPEND_TGT="$ASM" SPRAY_N=1 "${PYTEST[@]}" "$T::test_append_file" >/dev/null 2>&1
+    local s2
+    for s2 in $(seq 1 8); do
+      LC_ALL=C tail -n +"$((mark+1))" "$LOG" | grep -aq "AppendFileSucceeded" && break 2
+      sleep 2
+    done
+  done
+done
+echo "[tier1]   reassembled in $(( $(now)-tasm ))s"
+
+# --- final whole-file verify ---
+mark=$(wc -l <"$LOG")
+CRC_FILE="$ASM" SPRAY_N=10 "${PYTEST[@]}" "$T::test_calc_crc" >/dev/null 2>&1; sleep 1
+got=$(LC_ALL=C tail -n +"$((mark+1))" "$LOG" | LC_ALL=C grep -aoE "tp_asm.bin has CRC value 0x[0-9a-fA-F]+" | tail -1 | grep -aoE "0x[0-9a-fA-F]+")
+echo "[tier1] FINAL $ASM crc=$got expected=$(fcrc "$SRC")  total=$(( $(now)-GRAND0 ))s"
+[ "${got,,}" = "$(fcrc "$SRC")" ] && echo "[tier1] *** UPDATE INTACT ***" || echo "[tier1] *** FINAL MISMATCH ***"

--- a/PROVESFlightControllerReference/test/int/bridge_uplink_test.py
+++ b/PROVESFlightControllerReference/test/int/bridge_uplink_test.py
@@ -329,6 +329,125 @@ def test_detect_drops(fprime_test_api: IntegrationTestAPI):
     _t.sleep(5)
 
 
+def test_suppress_tm(fprime_test_api: IntegrationTestAPI):
+    """Set telemetryDelay divider high to reduce TM competition on the LoRa queue.
+
+    env TM_DIVIDER (default 60 = 6 s between TM packets). Spray so one lands.
+    """
+    import time as _t
+
+    div = int(os.environ.get("TM_DIVIDER", "60"))
+    n = int(os.environ.get("SPRAY_N", "12"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for _ in range(n):
+        fprime_test_api.send_command(
+            "ReferenceDeployment.telemetryDelay.DIVIDER_PRM_SET", [div]
+        )
+        _t.sleep(gap)
+    print(f"[tm] sprayed {n} telemetryDelay.DIVIDER_PRM_SET({div})")
+    _t.sleep(3)
+
+
+def test_send_file(fprime_test_api: IntegrationTestAPI):
+    """Trigger fileDownlink.SendFile from the flight FS to the GDS.
+
+    env DL_SRC (default //tp_asm.bin), DL_DEST (default tp_asm.bin).
+    File lands at <GDS file-storage>/fprime-downlink/<DL_DEST>.
+    Spray so one command lands in a flight RX window.
+    """
+    import time as _t
+
+    src = os.environ.get("DL_SRC", "//tp_asm.bin")
+    dest = os.environ.get("DL_DEST", "tp_asm.bin")
+    n = int(os.environ.get("SPRAY_N", "12"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for _ in range(n):
+        fprime_test_api.send_command("FileHandling.fileDownlink.SendFile", [src, dest])
+        _t.sleep(gap)
+    print(f"[dl] sprayed {n} SendFile {src} -> {dest}")
+    _t.sleep(5)
+
+
+def test_send_partial(fprime_test_api: IntegrationTestAPI):
+    """Trigger fileDownlink.SendPartial for a byte range of a flight-FS file.
+
+    env DL_SRC, DL_DEST, DL_OFFSET (default 0), DL_LENGTH (default 4096).
+    Useful for re-downlinking only dropped portions or testing segment timing.
+    """
+    import time as _t
+
+    src = os.environ.get("DL_SRC", "//tp_asm.bin")
+    dest = os.environ.get("DL_DEST", "tp_asm_part.bin")
+    offset = int(os.environ.get("DL_OFFSET", "0"))
+    length = int(os.environ.get("DL_LENGTH", "4096"))
+    n = int(os.environ.get("SPRAY_N", "12"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for _ in range(n):
+        fprime_test_api.send_command(
+            "FileHandling.fileDownlink.SendPartial", [src, dest, offset, length]
+        )
+        _t.sleep(gap)
+    print(f"[dl] sprayed {n} SendPartial {src}[{offset}:{offset + length}] -> {dest}")
+    _t.sleep(5)
+
+
+def test_cancel_downlink(fprime_test_api: IntegrationTestAPI):
+    """Send fileDownlink.Cancel to abort an in-progress downlink. Spray to land."""
+    import time as _t
+
+    n = int(os.environ.get("SPRAY_N", "12"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for _ in range(n):
+        fprime_test_api.send_command("FileHandling.fileDownlink.Cancel")
+        _t.sleep(gap)
+    print(f"[dl] sprayed {n} fileDownlink.Cancel")
+    _t.sleep(3)
+
+
+def test_await_downlink(fprime_test_api: IntegrationTestAPI):
+    """Poll for a file to arrive in the GDS fprime-downlink directory.
+
+    env DL_DEST (default tp_asm.bin), DL_STORAGE (default /tmp/ossf-1),
+    WATCH_SECS (default 300). Prints size and elapsed time once the file
+    stops growing (stable for 3 s). Records DLSTART / DLEND timestamps.
+    """
+    import time as _t
+
+    dest = os.environ.get("DL_DEST", "tp_asm.bin")
+    storage = os.environ.get("DL_STORAGE", "/tmp/ossf-1")
+    secs = float(os.environ.get("WATCH_SECS", "300"))
+    path = os.path.join(storage, "fprime-downlink", dest)
+    t0 = _t.time()
+    print(f"DLSTART {t0:.3f}", flush=True)
+    print(f"[await_dl] watching {path} for up to {secs}s ...", flush=True)
+    t_end = t0 + secs
+    prev_size = -1
+    stable_since = None
+    while _t.time() < t_end:
+        try:
+            sz = os.path.getsize(path)
+            if sz != prev_size:
+                print(
+                    f"[await_dl] {path}: {sz} bytes @ +{_t.time() - t0:.1f}s",
+                    flush=True,
+                )
+                prev_size = sz
+                stable_since = _t.time()
+            elif stable_since and _t.time() - stable_since >= 3:
+                elapsed = _t.time() - t0
+                print(f"DLEND {_t.time():.3f}", flush=True)
+                print(
+                    f"[await_dl] DONE: {sz} bytes in {elapsed:.1f}s"
+                    f" = {sz / elapsed:.1f} B/s",
+                    flush=True,
+                )
+                return
+        except FileNotFoundError:
+            pass
+        _t.sleep(0.5)
+    print(f"[await_dl] TIMEOUT: {dest} not complete in {secs}s", flush=True)
+
+
 @pytest.mark.parametrize(
     "src", [os.environ.get("UPLINK_SRC", "/tmp/grc_scratch_2k.bin")]
 )

--- a/PROVESFlightControllerReference/test/int/bridge_uplink_test.py
+++ b/PROVESFlightControllerReference/test/int/bridge_uplink_test.py
@@ -64,6 +64,31 @@ def test_watch_events(fprime_test_api: IntegrationTestAPI):
         print(f"[ev] {ev}")
 
 
+def test_watch_events_multi(fprime_test_api: IntegrationTestAPI):
+    """Watch several event names at once for WATCH_SECS. env WATCH_EVENTS
+    (comma-separated fully-qualified names), WATCH_SECS. Reports per-event COUNT
+    and prints every captured instance. Used to passively capture the GRC
+    ByteComBridge warning events during a transfer (point at GRC GDS 50060)."""
+    import os as _os
+    import time as _t
+
+    secs = float(_os.environ.get("WATCH_SECS", "60"))
+    names = [n for n in _os.environ.get("WATCH_EVENTS", "").split(",") if n]
+    subs = {
+        n: fprime_test_api.get_event_subhistory(
+            event_filter=fprime_test_api.get_event_pred(event=n)
+        )
+        for n in names
+    }
+    print(f"[multi] watching {len(names)} events for {secs}s ...", flush=True)
+    _t.sleep(secs)
+    for n, sub in subs.items():
+        items = list(sub.retrieve())
+        print(f"[multi] COUNT={len(items)} {n}")
+        for ev in items:
+            print(f"[mev] {ev}")
+
+
 def test_await_filerx(fprime_test_api: IntegrationTestAPI):
     """Watch the FC GDS (21101) for FileUplink completion, print wall-clock on first hit.
 

--- a/PROVESFlightControllerReference/test/int/bridge_uplink_test.py
+++ b/PROVESFlightControllerReference/test/int/bridge_uplink_test.py
@@ -1,0 +1,160 @@
+"""
+End-to-end bridge test: GDS -> GRC data port (21203) -> LoRa -> flight board.
+
+Validates the authenticated command/file-uplink link through the GRC LoRa
+bridge. Run with fprime-gds already attached to the GRC data port.
+"""
+
+import hashlib
+import os
+
+import pytest
+from fprime_gds.common.testing_fw.api import IntegrationTestAPI
+
+
+def test_noop(fprime_test_api: IntegrationTestAPI):
+    """Tracer bullet: a single authenticated NO_OP must round-trip over LoRa."""
+    fprime_test_api.send_and_assert_command(
+        "CdhCore.cmdDisp.CMD_NO_OP", timeout=30, max_delay=30
+    )
+
+
+def test_get_seq(fprime_test_api: IntegrationTestAPI):
+    """Send bypass GET_SEQ_NUM; the seq is emitted to the flight console."""
+    fprime_test_api.send_command("ComCcsdsLora.authenticatelora.GET_SEQ_NUM")
+    print(
+        "[seq] GET_SEQ_NUM sent over LoRa (watch flight console for EmitSequenceNumber)"
+    )
+    import time as _t
+
+    _t.sleep(8)
+
+
+def test_spray_seq(fprime_test_api: IntegrationTestAPI):
+    """Spray many bypass GET_SEQ_NUM rapidly to land one in a flight RX window."""
+    import time as _t
+
+    n = int(os.environ.get("SPRAY_N", "20"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for i in range(n):
+        fprime_test_api.send_command("ComCcsdsLora.authenticatelora.GET_SEQ_NUM")
+        _t.sleep(gap)
+    print(f"[spray] sent {n} GET_SEQ_NUM @ {gap}s")
+    _t.sleep(5)
+
+
+def test_spray_disable_tx(fprime_test_api: IntegrationTestAPI):
+    """Spray lora.TRANSMIT TX_STATE (default DISABLED) rapidly (non-bypass; needs synced seq)."""
+    import time as _t
+
+    state = os.environ.get("TX_STATE", "DISABLED")
+    n = int(os.environ.get("SPRAY_N", "20"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for i in range(n):
+        fprime_test_api.send_command("ReferenceDeployment.lora.TRANSMIT", [state])
+        _t.sleep(gap)
+    print(f"[spray] sent {n} lora.TRANSMIT {state} @ {gap}s")
+    _t.sleep(5)
+
+
+def test_enable_tx(fprime_test_api: IntegrationTestAPI):
+    """Enable flight LoRa transmit + set a fast downlink divider (non-bypass: needs synced seq)."""
+    div = int(os.environ.get("DOWNLINK_DIVIDER", "5"))
+    fprime_test_api.send_command(
+        "ReferenceDeployment.downlinkDelay.DIVIDER_PRM_SET", [div]
+    )
+    fprime_test_api.send_command("ReferenceDeployment.lora.TRANSMIT", ["ENABLED"])
+    print(f"[tx] sent DIVIDER_PRM_SET({div}) + lora.TRANSMIT(ENABLED) over LoRa")
+    import time as _t
+
+    _t.sleep(8)
+
+
+def test_append_file(fprime_test_api: IntegrationTestAPI):
+    """Spray fileManager.AppendFile APPEND_SRC -> APPEND_TGT (non-bypass; reassembles parts)."""
+    import time as _t
+
+    src = os.environ["APPEND_SRC"]
+    tgt = os.environ["APPEND_TGT"]
+    n = int(os.environ.get("SPRAY_N", "12"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for i in range(n):
+        fprime_test_api.send_command("FileHandling.fileManager.AppendFile", [src, tgt])
+        _t.sleep(gap)
+    print(f"[append] sprayed {n} AppendFile {src} -> {tgt}")
+    _t.sleep(5)
+
+
+def test_remove_file(fprime_test_api: IntegrationTestAPI):
+    """Spray fileManager.RemoveFile RM_FILE (ignoreErrors=True) to clear stale dests."""
+    import time as _t
+
+    f = os.environ["RM_FILE"]
+    n = int(os.environ.get("SPRAY_N", "10"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for i in range(n):
+        fprime_test_api.send_command("FileHandling.fileManager.RemoveFile", [f, True])
+        _t.sleep(gap)
+    print(f"[rm] sprayed {n} RemoveFile {f}")
+    _t.sleep(3)
+
+
+def test_calc_crc(fprime_test_api: IntegrationTestAPI):
+    """Spray fileManager.CalculateCrc over CRC_FILE (non-bypass; needs synced seq).
+
+    Emits CalculateCrcSucceeded : <file> has CRC value 0x.. on the flight console.
+    Read-back oracle for verifying a patched file against the local truth CRC.
+    """
+    import time as _t
+
+    f = os.environ.get("CRC_FILE", "//ota_q1.bin")
+    n = int(os.environ.get("SPRAY_N", "15"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for i in range(n):
+        fprime_test_api.send_command("FileHandling.fileManager.CalculateCrc", [f])
+        _t.sleep(gap)
+    print(
+        f"[crc] sprayed {n} CalculateCrc {f} @ {gap}s (watch console for CalculateCrcSucceeded)"
+    )
+    _t.sleep(6)
+
+
+def test_detect_drops(fprime_test_api: IntegrationTestAPI):
+    """Spray dropDetector.DETECT_DROPS over the file just uplinked (non-bypass; needs synced seq).
+
+    The board scans <DETECT_FILE> for runs of <DETECT_PKT> zero-bytes (dropped
+    chunks left as zeros by FileUplink's offset writes) and emits PossibleDrop
+    events (1-based chunk index) plus DetectingDrops/DetectingDropsCompleted on
+    the flight console. Spray so one send lands in a flight RX window.
+    """
+    import time as _t
+
+    f = os.environ.get("DETECT_FILE", "//ota_patch.bin")
+    pkt = int(os.environ.get("DETECT_PKT", "204"))
+    n = int(os.environ.get("SPRAY_N", "15"))
+    gap = float(os.environ.get("SPRAY_GAP", "0.3"))
+    for i in range(n):
+        fprime_test_api.send_command(
+            "ReferenceDeployment.dropDetector.DETECT_DROPS", [f, pkt]
+        )
+        _t.sleep(gap)
+    print(
+        f"[detect] sprayed {n} DETECT_DROPS {f} {pkt} @ {gap}s (watch console for PossibleDrop)"
+    )
+    _t.sleep(5)
+
+
+@pytest.mark.parametrize(
+    "src", [os.environ.get("UPLINK_SRC", "/tmp/grc_scratch_2k.bin")]
+)
+def test_uplink_file(fprime_test_api: IntegrationTestAPI, src):
+    """Uplink a file over the LoRa bridge and await FileUplink completion."""
+    dest = os.environ.get("UPLINK_DEST", "//bridge_test.bin")
+    timeout = int(os.environ.get("UPLINK_TIMEOUT", "120"))
+    with open(src, "rb") as f:
+        digest = hashlib.md5(f.read()).hexdigest()
+    print(
+        f"\n[uplink] src={src} dest={dest} size={os.path.getsize(src)} md5={digest} timeout={timeout}s"
+    )
+    fprime_test_api.uplink_file_and_await_completion(src, dest, timeout=timeout)
+    print(f"[uplink] completion received for {dest}")

--- a/PROVESFlightControllerReference/test/int/bridge_uplink_test.py
+++ b/PROVESFlightControllerReference/test/int/bridge_uplink_test.py
@@ -19,6 +19,144 @@ def test_noop(fprime_test_api: IntegrationTestAPI):
     )
 
 
+def test_send_cmd(fprime_test_api: IntegrationTestAPI):
+    """Fire-and-forget any command (no ack needed). env CMD, optional ARGS (comma-sep).
+
+    Used to command the GRC over its (downlink-less) control port, e.g.
+    CMD=ReferenceDeployment.uhf.DATA_RATE_PRM_SET ARGS=SF_7
+    """
+    import os as _os
+    import time as _t
+
+    cmd = _os.environ["CMD"]
+    raw = _os.environ.get("ARGS", "")
+    args = [a for a in raw.split(",") if a != ""]
+    reps = int(_os.environ.get("REPS", "1"))
+    gap = float(_os.environ.get("GAP", "0.4"))
+    for _ in range(reps):
+        fprime_test_api.send_command(cmd, args)
+        _t.sleep(gap)
+    print(f"[cmd] sent {cmd} {args} x{reps}")
+    _t.sleep(2)
+
+
+def test_watch_events(fprime_test_api: IntegrationTestAPI):
+    """Passively watch this GDS's decoded event stream for WATCH_SECS seconds.
+
+    Use against the FC direct GDS (21101) to read flight events even when the
+    ASCII console capture is stale. env WATCH_SECS (default 20), WATCH_FILTER
+    (substring; only matching events printed).
+    """
+    import os as _os
+    import time as _t
+
+    secs = float(_os.environ.get("WATCH_SECS", "20"))
+    name = _os.environ.get(
+        "WATCH_EVENT", "ComCcsdsLora.authenticatelora.EmitSequenceNumber"
+    )
+    pred = fprime_test_api.get_event_pred(event=name)
+    sub = fprime_test_api.get_event_subhistory(event_filter=pred)
+    print(f"[watch] collecting '{name}' for {secs}s ...")
+    _t.sleep(secs)
+    items = list(sub.retrieve())
+    print(f"[watch] COUNT={len(items)} of '{name}' in {secs}s")
+    for ev in items[-5:]:
+        print(f"[ev] {ev}")
+
+
+def test_await_filerx(fprime_test_api: IntegrationTestAPI):
+    """Watch the FC GDS (21101) for FileUplink completion, print wall-clock on first hit.
+
+    Polls subhistories for FileReceived (success) and BadChecksum (over-air loss)
+    up to WATCH_SECS. Prints `FRX <unix_time> <text>` / `BADCRC <unix_time> <text>`
+    the instant one is seen, then exits — used to measure transfer time vs a t0
+    recorded by the caller. env WATCH_SECS (default 120).
+    """
+    import time as _t
+
+    secs = float(os.environ.get("WATCH_SECS", "120"))
+    ok = fprime_test_api.get_event_subhistory(
+        event_filter=fprime_test_api.get_event_pred(
+            event="FileHandling.fileUplink.FileReceived"
+        )
+    )
+    bad = fprime_test_api.get_event_subhistory(
+        event_filter=fprime_test_api.get_event_pred(
+            event="FileHandling.fileUplink.BadChecksum"
+        )
+    )
+    print(
+        f"[await] watching FileReceived/BadChecksum for up to {secs}s ...", flush=True
+    )
+    t_end = _t.time() + secs
+    while _t.time() < t_end:
+        oi = list(ok.retrieve())
+        if oi:
+            print(f"FRX {_t.time():.3f} {oi[-1]}", flush=True)
+            return
+        bi = list(bad.retrieve())
+        if bi:
+            print(f"BADCRC {_t.time():.3f} {bi[-1]}", flush=True)
+            return
+        _t.sleep(0.2)
+    print(f"[await] TIMEOUT no FileReceived/BadChecksum in {secs}s", flush=True)
+
+
+def test_send_assert(fprime_test_api: IntegrationTestAPI):
+    """Send a command and assert the cmd RESPONSE is OK. env CMD, ARGS, TIMEOUT.
+
+    Used to read the GRC command verdict (e.g. CONTINUOUS_WAVE OK vs EXECUTION_ERROR)
+    over a port that DOES have a control downlink (the GRC console GDS).
+    """
+    import os as _os
+
+    cmd = _os.environ["CMD"]
+    raw = _os.environ.get("ARGS", "")
+    args = [a for a in raw.split(",") if a != ""]
+    timeout = int(_os.environ.get("TIMEOUT", "15"))
+    fprime_test_api.send_and_assert_command(
+        cmd, args=args, max_delay=timeout, timeout=timeout
+    )
+
+
+def test_listen_events(fprime_test_api: IntegrationTestAPI):
+    """Passively collect decoded events for LISTEN_SECS and print them.
+
+    Run against the FC-direct GDS (USB) to observe the flight's verdict for a
+    command injected over the radio via the bridge GDS. Independent of LoRa
+    downlink / flight TX state.
+    """
+    import os as _os
+    import time as _t
+
+    secs = int(_os.environ.get("LISTEN_SECS", "30"))
+    fprime_test_api.clear_histories()
+    print(f"[listen] collecting events for {secs}s ...")
+    _t.sleep(secs)
+    hist = fprime_test_api.get_event_test_history()
+    items = list(hist.retrieve())
+    print(f"[listen] {len(items)} events:")
+    for it in items:
+        print(
+            "EVT",
+            it.get_time(),
+            it.template.get_full_name(),
+            "|",
+            it.get_display_text(),
+        )
+    tlm_hist = fprime_test_api.get_telemetry_test_history()
+    tlm_items = list(tlm_hist.retrieve())
+    print(f"[listen] {len(tlm_items)} telemetry updates:")
+    for it in tlm_items:
+        print(
+            "TLM",
+            it.get_time(),
+            it.template.get_full_name(),
+            "=",
+            it.get_display_text(),
+        )
+
+
 def test_get_seq(fprime_test_api: IntegrationTestAPI):
     """Send bypass GET_SEQ_NUM; the seq is emitted to the flight console."""
     fprime_test_api.send_command("ComCcsdsLora.authenticatelora.GET_SEQ_NUM")
@@ -41,6 +179,28 @@ def test_spray_seq(fprime_test_api: IntegrationTestAPI):
         _t.sleep(gap)
     print(f"[spray] sent {n} GET_SEQ_NUM @ {gap}s")
     _t.sleep(5)
+
+
+def test_spray_mixed_seq_noop(fprime_test_api: IntegrationTestAPI):
+    """Interleave bypass GET_SEQ_NUM (window detector) and NO_OP (the goal).
+
+    Whenever a flight RX window opens, both are in flight: GET_SEQ_NUM emits
+    EmitSequenceNumber (proves the window/link is open + reports auth `expected`),
+    and NO_OP lands NoOpReceived IFF the GDS framer seq is in window. Lets us
+    distinguish "link dark" (neither lands) from "seq out of window" (only
+    GET_SEQ_NUM lands) in a single run. env REPS (pairs), GAP.
+    """
+    import time as _t
+
+    reps = int(os.environ.get("REPS", "120"))
+    gap = float(os.environ.get("GAP", "0.4"))
+    for i in range(reps):
+        fprime_test_api.send_command("ComCcsdsLora.authenticatelora.GET_SEQ_NUM")
+        _t.sleep(gap)
+        fprime_test_api.send_command("CdhCore.cmdDisp.CMD_NO_OP")
+        _t.sleep(gap)
+    print(f"[mixed] sent {reps} (GET_SEQ_NUM + NO_OP) pairs @ {gap}s")
+    _t.sleep(3)
 
 
 def test_spray_disable_tx(fprime_test_api: IntegrationTestAPI):
@@ -156,5 +316,12 @@ def test_uplink_file(fprime_test_api: IntegrationTestAPI, src):
     print(
         f"\n[uplink] src={src} dest={dest} size={os.path.getsize(src)} md5={digest} timeout={timeout}s"
     )
-    fprime_test_api.uplink_file_and_await_completion(src, dest, timeout=timeout)
-    print(f"[uplink] completion received for {dest}")
+    import time as _t
+
+    print(f"UPSTART {_t.time():.3f}", flush=True)
+    try:
+        fprime_test_api.uplink_file_and_await_completion(src, dest, timeout=timeout)
+    except Exception as e:
+        print(f"[uplink] await ended: {type(e).__name__} (expected in TX-off mode)")
+    print(f"UPEND {_t.time():.3f}", flush=True)
+    print(f"[uplink] send phase done for {dest}")

--- a/PROVESFlightControllerReference/test/int/radio_test.py
+++ b/PROVESFlightControllerReference/test/int/radio_test.py
@@ -1,0 +1,118 @@
+"""
+radio_test.py:
+
+Integration tests for the Radio.
+"""
+
+import time
+from datetime import datetime
+
+import pytest
+from common import proves_send_and_assert_command
+from fprime_gds.common.models.serialize.time_type import TimeType
+from fprime_gds.common.testing_fw.api import IntegrationTestAPI
+
+pytestmark = [pytest.mark.uart_only]
+
+downlinkDelay = "ReferenceDeployment.downlinkDelay"
+lora = "ReferenceDeployment.lora"
+
+LORA_ERROR_EVENTS = ("SendFailed", "ConfigurationFailed", "AllocationFailed")
+
+# Continuous-wave burst duration (seconds) for the CW regression test. Kept short so
+# the command stays within the GDS command-completion timeout while still exercising
+# the asynchronous TxTimeout teardown path.
+CW_SECONDS = 5
+
+
+@pytest.fixture(autouse=True)
+def setup_test(fprime_test_api: IntegrationTestAPI, start_gds):
+    """Fixture to set the downlink divider before each test and disable transmit after each test"""
+    proves_send_and_assert_command(
+        fprime_test_api,
+        f"{downlinkDelay}.DIVIDER_PRM_SET",
+        [20],
+    )
+    yield
+    proves_send_and_assert_command(
+        fprime_test_api,
+        f"{lora}.TRANSMIT",
+        ["DISABLED"],
+    )
+
+
+def test_01_transmit_enabled(fprime_test_api: IntegrationTestAPI, start_gds):
+    """Enabling transmit must not produce any LoRa error/warning events."""
+    start: TimeType = TimeType().set_datetime(
+        datetime.now(), time_base=TimeType.TimeBase("TB_DONT_CARE")
+    )
+
+    proves_send_and_assert_command(
+        fprime_test_api,
+        f"{lora}.TRANSMIT",
+        ["ENABLED"],
+    )
+
+    time.sleep(10)
+
+    for evt in LORA_ERROR_EVENTS:
+        result = fprime_test_api.await_event(f"{lora}.{evt}", start=start, timeout=0)
+        assert result is None, f"Unexpected {lora}.{evt}: {result}"
+
+
+def test_02_continuous_wave_repeated(fprime_test_api: IntegrationTestAPI, start_gds):
+    """Regression test for issue #207.
+
+    CONTINUOUS_WAVE used to return EXECUTION_ERROR on every call and physically
+    transmit only on the first call, leaving the modem wedged (no TX/RX) until a
+    board reset. The root cause was the handler re-arming RX while the asynchronous
+    continuous wave still held the modem BUSY. This test sends CONTINUOUS_WAVE twice
+    and asserts that both calls succeed, that no ConfigurationFailed event is logged
+    by the second call, and that a normal transmit path still works afterwards (i.e.
+    the modem is not wedged).
+    """
+    # First continuous-wave burst. Before the fix this still transmitted once but
+    # returned EXECUTION_ERROR, so send_and_assert_command would already fail here.
+    proves_send_and_assert_command(
+        fprime_test_api,
+        f"{lora}.CONTINUOUS_WAVE",
+        [CW_SECONDS],
+    )
+
+    # Wait out the CW duration so the modem fully tears down before the next call.
+    time.sleep(CW_SECONDS + 2)
+
+    # Second continuous-wave burst. This is the call that failed before the fix
+    # (modem left wedged after the first CW), so OK here is the key regression signal.
+    start: TimeType = TimeType().set_datetime(
+        datetime.now(), time_base=TimeType.TimeBase("TB_DONT_CARE")
+    )
+    proves_send_and_assert_command(
+        fprime_test_api,
+        f"{lora}.CONTINUOUS_WAVE",
+        [CW_SECONDS],
+    )
+    time.sleep(CW_SECONDS + 2)
+
+    # The repeated CW must not have logged a modem configuration failure.
+    result = fprime_test_api.await_event(
+        f"{lora}.ConfigurationFailed", start=start, timeout=0
+    )
+    assert result is None, (
+        f"Unexpected {lora}.ConfigurationFailed after repeated CW: {result}"
+    )
+
+    # The radio must still be usable for normal transmission after the CW bursts;
+    # a wedged modem would surface as LoRa error events here.
+    start = TimeType().set_datetime(
+        datetime.now(), time_base=TimeType.TimeBase("TB_DONT_CARE")
+    )
+    proves_send_and_assert_command(
+        fprime_test_api,
+        f"{lora}.TRANSMIT",
+        ["ENABLED"],
+    )
+    time.sleep(10)
+    for evt in LORA_ERROR_EVENTS:
+        result = fprime_test_api.await_event(f"{lora}.{evt}", start=start, timeout=0)
+        assert result is None, f"Unexpected {lora}.{evt} after repeated CW: {result}"

--- a/sequences/pass-10min.seq
+++ b/sequences/pass-10min.seq
@@ -1,0 +1,6 @@
+; Set the comm dividers to a safe value for a 10 minute ground station pass.
+R00:00:00 ReferenceDeployment.downlinkDelay.DIVIDER_PRM_SET, 20
+R00:00:00 ReferenceDeployment.telemetryDelay.DIVIDER_PRM_SET, 4
+R00:10:00 CdhCore.cmdDisp.CMD_NO_OP_STRING, "Catch you on the next pass!"
+R00:00:00 ReferenceDeployment.downlinkDelay.DIVIDER_PRM_SET, 300
+R00:00:00 ReferenceDeployment.telemetryDelay.DIVIDER_PRM_SET, 30

--- a/tools/yamcs/proves_adapter.py
+++ b/tools/yamcs/proves_adapter.py
@@ -5,6 +5,11 @@ Routes TM frames from the spacecraft to YAMCS (via UDP) and TC frames from
 YAMCS (via UDP) back to the spacecraft after wrapping them with the HMAC-SHA256
 authentication header/trailer required by the FSW Authenticate component.
 
+The adapter is promiscuous on the TM side: it accepts frames from any CCSDS
+spacecraft ID and normalizes them to ``--spacecraft-id`` before forwarding, so
+a single YAMCS instance can capture telemetry from multiple satellites through
+a single GRC board without knowing their SCIDs in advance.
+
 Use Case 1 (local UART):
     python proves_adapter.py --mode serial --uart-device /dev/ttyUSB0
 
@@ -54,6 +59,25 @@ from fprime_gds.common.communication.ccsds.space_data_link import (  # noqa: E40
 # ---------------------------------------------------------------------------
 
 
+def _normalize_tm_scid(frame: bytes, spacecraft_id: int, vc_id: int) -> bytes:
+    """Overwrite bytes 0-1 of a CCSDS TM frame with the target SCID/VCID and recompute CRC.
+
+    CCSDS TM primary header word0 (bytes 0-1):
+      bits 15-14: version=0
+      bits 13-4:  spacecraft_id (10 bits)
+      bits 3-1:   vc_id (3 bits)
+      bit 0:      OCF flag = 0
+    """
+    word0 = (spacecraft_id << 4) | (vc_id << 1)
+    out = bytearray(frame)
+    out[0] = (word0 >> 8) & 0xFF
+    out[1] = word0 & 0xFF
+    crc = _crc16_ccitt(bytes(out[:-2]))
+    out[-2] = (crc >> 8) & 0xFF
+    out[-1] = crc & 0xFF
+    return bytes(out)
+
+
 def _forward_tm_serial(
     ser,
     tm_sock,
@@ -65,65 +89,54 @@ def _forward_tm_serial(
 ):
     """Read fixed-length TM frames from serial and forward to YAMCS via UDP.
 
-    The FSW may interleave console/debug text (e.g. ``[Os::...]``) on the same
-    UART as CCSDS TM frames.  Rather than reading exactly *frame_length* bytes
-    and hoping they form a clean frame, we maintain a rolling buffer and scan for
-    the 2-byte sync header.  When found, we validate the CRC — if it passes the
-    frame is forwarded; if it fails the candidate is discarded and scanning
-    continues.  This makes the adapter resilient to arbitrary non-frame data on
-    the serial link without losing the frame that immediately follows.
+    Operates in promiscuous mode: accepts frames from any spacecraft ID by
+    validating only the CRC-16/CCITT, not the embedded SCID.  Before forwarding,
+    the adapter normalizes the SCID/VCID bytes (header bytes 0-1) to match
+    ``spacecraft_id``/``vc_id`` and recomputes the frame CRC so YAMCS always
+    sees a consistent spacecraft ID regardless of which satellite sent the frame.
+
+    Uses a HUNT/LOCK state machine:
+      HUNT — slide 1 byte at a time until a CRC-valid frame is found.
+      LOCK — once in sync, expect the next frame exactly ``frame_length``
+             bytes later; fall back to HUNT on CRC failure.
     """
     import time
 
     print(f"[TM] serial → UDP {yamcs_host}:{tm_port}  (frame_length={frame_length})")
-    # Compute the expected first 2 bytes of the CCSDS TM primary header:
-    # bits 15-14: version=0, bits 13-4: spacecraft_id, bits 3-1: vc_id, bit 0: OCF=0
-    word0 = (spacecraft_id << 4) | (vc_id << 1)
-    sync_header = bytes([(word0 >> 8) & 0xFF, word0 & 0xFF])
+    print(
+        f"[TM] Promiscuous: accepting any SCID, normalizing to SCID={spacecraft_id} VCID={vc_id}"
+    )
 
     buf = bytearray()
     frames_sent = 0
-    last_vc_count = -1  # not yet known
+    last_vc_count = -1
     vc_frame_gaps = 0
     junk_bytes = 0
+    locked = False
     stats_time = time.monotonic()
 
-    print(f"[TM] Scanning for frames (sync header={sync_header.hex(' ')})...")
-
     while True:
-        # Read whatever is available (up to 4 KB) to keep the OS buffer drained.
         chunk = ser.read(max(1, ser.in_waiting or 1))
         if not chunk:
             continue
         buf.extend(chunk)
 
-        # Scan the buffer for complete, CRC-valid frames.
-        while True:
-            # Find the sync header in the buffer.
-            idx = buf.find(sync_header)
-            if idx == -1:
-                # No sync header anywhere — discard everything except the last
-                # byte (which could be the first byte of a future sync header).
-                if len(buf) > 1:
-                    junk_bytes += len(buf) - 1
-                    del buf[: len(buf) - 1]
-                break
-
-            # Discard any non-frame bytes before the sync header.
-            if idx > 0:
-                junk_bytes += idx
-                del buf[:idx]
-
-            # Need a full frame to validate.
-            if len(buf) < frame_length:
-                break  # wait for more data
-
+        while len(buf) >= frame_length:
             candidate = bytes(buf[:frame_length])
             if _crc16_ccitt(candidate[:-2]) == int.from_bytes(candidate[-2:], "big"):
-                # Valid frame — forward it.
+                # CRC-valid frame — normalize SCID if needed.
+                real_word0 = (candidate[0] << 8) | candidate[1]
+                real_scid = (real_word0 >> 4) & 0x3FF
+                if real_scid != spacecraft_id:
+                    if not locked:
+                        print(
+                            f"[TM] acquired lock: SCID={real_scid} → normalizing to {spacecraft_id}"
+                        )
+                    candidate = _normalize_tm_scid(candidate, spacecraft_id, vc_id)
+
+                locked = True
                 del buf[:frame_length]
 
-                # VC frame count gap detection (byte 3 of TM primary header).
                 vc_count = candidate[3]
                 if last_vc_count >= 0:
                     expected_vc = (last_vc_count + 1) & 0xFF
@@ -139,12 +152,12 @@ def _forward_tm_serial(
                 tm_sock.sendto(candidate, (yamcs_host, tm_port))
                 frames_sent += 1
             else:
-                # CRC mismatch — sync header was a false positive (or the
-                # frame was corrupted by interleaved text).  Skip past the
-                # 2 sync-header bytes and keep scanning from the next byte.
-                del buf[:2]
+                if locked:
+                    print("[TM] lost frame sync, hunting...")
+                    locked = False
+                junk_bytes += 1
+                del buf[:1]
 
-        # Periodic stats every 30 seconds.
         now = time.monotonic()
         if now - stats_time >= 30.0:
             elapsed = now - stats_time
@@ -155,6 +168,7 @@ def _forward_tm_serial(
             )
             stats_time = now
             frames_sent = 0
+            vc_frame_gaps = 0
             junk_bytes = 0
 
 
@@ -282,6 +296,9 @@ def _forward_tc_serial(
             )
             continue
         ser.write(out_frame)
+        print(
+            f"[TC] forwarded {len(tc_transfer_frame)}B YAMCS frame → {len(out_frame)}B auth'd TC frame"
+        )
 
 
 def _forward_tc_tcp(
@@ -399,8 +416,11 @@ def main():
 
     # Shared UDP sockets
     tm_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    tc_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    tc_sock.bind(("0.0.0.0", args.yamcs_tc_port))
+    # Dual-stack so we receive TC from YAMCS whether it sends to 127.0.0.1 or ::1.
+    # macOS resolves "localhost" to ::1 by default, so AF_INET alone misses those packets.
+    tc_sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+    tc_sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    tc_sock.bind(("", args.yamcs_tc_port))
 
     if args.mode == "serial":
         import serial  # pyserial — installed via requirements.txt


### PR DESCRIPTION
## Summary

- Replaces the sync-header-based frame scan (which filtered by SCID) with a CRC-16/CCITT-only HUNT/LOCK state machine, so the adapter accepts TM frames from any satellite regardless of the embedded spacecraft ID
- Before forwarding to YAMCS, frames are SCID-normalized to `--spacecraft-id` (default 68) and the CRC is recomputed — YAMCS's `spacecraftId` filter still passes with no config change
- Logs the real SCID on first lock (`[TM] acquired lock: SCID=69 → normalizing to 68`) for visibility

## Motivation

A single GRC board feeds a single YAMCS instance and may receive telemetry from multiple PROVES satellites whose spacecraft IDs are not yet known. This removes the requirement to know the SCID before running the adapter.

## Test plan

- [ ] `make yamcs UART_DEVICE=/dev/cu.<GRC>` launches cleanly against a single satellite (SCID=68, no normalization path exercised)
- [ ] Connect a second satellite with a different SCID and confirm `acquired lock` log line appears and telemetry flows into YAMCS

🤖 Generated with [Claude Code](https://claude.com/claude-code)