### PR TITLE
Fix test issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,13 @@ jobs:
         run: |
           make build
 
+      - name: Ensure console disabled
+        # The Zephyr console shares cdc_acm_uart0 with the F' downlink; if it is
+        # re-enabled, console text interleaves with the CCSDS TM frames and
+        # desyncs the GDS deframer. Fail the build so this cannot reach main.
+        run: |
+          make check-console-disabled
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,11 @@ build: submodules zephyr fprime-venv generate-if-needed ## Build FPrime-Zephyr P
 	mv ./build-artifacts/zephyr.signed.hex bootable.signed.hex
 	@if [ "$(BUILD_YAMCS_MDB)" = "1" ]; then $(MAKE) yamcs-mdb; else echo "Skipping yamcs-mdb (BUILD_YAMCS_MDB=$(BUILD_YAMCS_MDB))"; fi
 
+.PHONY: check-console-disabled
+ZEPHYR_CONFIG ?= $(BUILD_DIR)/zephyr/.config
+check-console-disabled: uv ## Fail if the Zephyr UART console is enabled (it corrupts the F' downlink); run after 'make build'
+	@$(UV_RUN) python3 scripts/check_console_disabled.py "$(ZEPHYR_CONFIG)"
+
 ##@ Authentication Keys
 
 AUTH_DEFAULT_KEY_HEADER ?= PROVESFlightControllerReference/Components/Authenticate/AuthDefaultKey.h

--- a/PROVESFlightControllerReference/project/config/ComCcsdsConfig.fpp
+++ b/PROVESFlightControllerReference/project/config/ComCcsdsConfig.fpp
@@ -23,7 +23,7 @@ module ComCcsdsConfig {
     # Queue configuration constants
     module QueueDepths {
         constant events      = 50
-        constant tlm         = 1
+        constant tlm         = 50
         constant file        = 1
     }
 

--- a/PROVESFlightControllerReference/project/config/ComCcsdsConfig.fpp
+++ b/PROVESFlightControllerReference/project/config/ComCcsdsConfig.fpp
@@ -23,7 +23,7 @@ module ComCcsdsConfig {
     # Queue configuration constants
     module QueueDepths {
         constant events      = 50
-        constant tlm         = 50
+        constant tlm         = 1
         constant file        = 1
     }
 

--- a/PROVESFlightControllerReference/test/int/burnwire_test.py
+++ b/PROVESFlightControllerReference/test/int/burnwire_test.py
@@ -11,7 +11,11 @@ from common import proves_send_and_assert_command
 from fprime_gds.common.data_types.event_data import EventData
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
 
-pytestmark = [pytest.mark.uart_only]
+pytestmark = [
+    pytest.mark.uart_only,
+    pytest.mark.requires_antenna,
+    pytest.mark.requires_battery,
+]
 
 ina219SysManager = "ReferenceDeployment.ina219SysManager"
 

--- a/PROVESFlightControllerReference/test/int/conftest.py
+++ b/PROVESFlightControllerReference/test/int/conftest.py
@@ -20,16 +20,45 @@ from fprime_gds.common.testing_fw.api import IntegrationTestAPI
 RADIO_STABILIZE_S = 15
 
 
+# Hardware that a bare flight control board does not have. When
+# --bare-flight-control-board is passed, tests carrying any of these markers are
+# skipped so the suite can run on the board alone.
+BARE_FCB_SKIP_MARKERS = {
+    "requires_face": "a face board",
+    "requires_antenna": "the antenna board and burnwire capacitor",
+    "requires_battery": "the battery board with power at the terminals",
+    "requires_watchdog_jumper": "the JP6 watchdog jumper bridged",
+}
+
+
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """When running with --with-radio, move RTC tests to the end of the collection.
+    """Adjust the collected tests for the current hardware/link configuration.
 
-    The RTC tests mutate the system clock (TIME_SET to -12 h from now) and the
-    teardown resets it to current UTC.  Running the RTC tests last prevents the
-    temporary clock change from racing with the test that immediately follows
-    alphabetically (TMP112), which is otherwise flaky on the radio path.
+    1. With --bare-flight-control-board, skip tests whose markers require add-on
+       hardware (face, antenna, battery, or the JP6 watchdog jumper).
+    2. With --with-radio, move the RTC tests to the end of the collection. The
+       RTC tests mutate the system clock (TIME_SET to -12 h from now) and the
+       teardown resets it to current UTC.  Running them last prevents the
+       temporary clock change from racing with the test that immediately follows
+       alphabetically (TMP112), which is otherwise flaky on the radio path.
     """
+    if config.getoption("--bare-flight-control-board", default=False):
+        for item in items:
+            needed = [
+                description
+                for marker, description in BARE_FCB_SKIP_MARKERS.items()
+                if item.get_closest_marker(marker) is not None
+            ]
+            if needed:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason="bare flight control board: requires "
+                        + "; ".join(needed)
+                    )
+                )
+
     if not config.getoption("--with-radio", default=False):
         return
 
@@ -50,6 +79,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         type=int,
         default=None,
         help="Override retry count for proves_send_and_assert_command (default: 3 UART, 5 radio).",
+    )
+    parser.addoption(
+        "--bare-flight-control-board",
+        action="store_true",
+        default=False,
+        help="Skip tests that require add-on hardware (face, antenna, battery, or "
+        "the JP6 watchdog jumper) so the suite can run on a bare flight control board.",
     )
 
 

--- a/PROVESFlightControllerReference/test/int/conftest.py
+++ b/PROVESFlightControllerReference/test/int/conftest.py
@@ -21,7 +21,7 @@ RADIO_STABILIZE_S = 15
 
 
 # Hardware that a bare flight control board does not have. When
-# --bare-flight-control-board is passed, tests carrying any of these markers are
+# --bare-flight-controler-board is passed, tests carrying any of these markers are
 # skipped so the suite can run on the board alone.
 BARE_FCB_SKIP_MARKERS = {
     "requires_face": "a face board",
@@ -36,7 +36,7 @@ def pytest_collection_modifyitems(
 ) -> None:
     """Adjust the collected tests for the current hardware/link configuration.
 
-    1. With --bare-flight-control-board, skip tests whose markers require add-on
+    1. With --bare-flight-controller-board, skip tests whose markers require add-on
        hardware (face, antenna, battery, or the JP6 watchdog jumper).
     2. With --with-radio, move the RTC tests to the end of the collection. The
        RTC tests mutate the system clock (TIME_SET to -12 h from now) and the
@@ -44,7 +44,7 @@ def pytest_collection_modifyitems(
        temporary clock change from racing with the test that immediately follows
        alphabetically (TMP112), which is otherwise flaky on the radio path.
     """
-    if config.getoption("--bare-flight-control-board", default=False):
+    if config.getoption("--bare-flight-controler-board", default=False):
         for item in items:
             needed = [
                 description
@@ -81,7 +81,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Override retry count for proves_send_and_assert_command (default: 3 UART, 5 radio).",
     )
     parser.addoption(
-        "--bare-flight-control-board",
+        "--bare-flight-controler-board",
         action="store_true",
         default=False,
         help="Skip tests that require add-on hardware (face, antenna, battery, or "

--- a/PROVESFlightControllerReference/test/int/drv2605_test.py
+++ b/PROVESFlightControllerReference/test/int/drv2605_test.py
@@ -12,6 +12,8 @@ from common import proves_send_and_assert_command
 from fprime_gds.common.models.serialize.time_type import TimeType
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
 
+pytestmark = [pytest.mark.requires_face]
+
 drv2605Manager = "ReferenceDeployment.drv2605Face0Manager"
 ina219SysManager = "ReferenceDeployment.ina219SysManager"
 

--- a/PROVESFlightControllerReference/test/int/power_monitor_test.py
+++ b/PROVESFlightControllerReference/test/int/power_monitor_test.py
@@ -4,9 +4,12 @@ power_monitor_test.py:
 Integration tests for the Power Monitor component.
 """
 
+import pytest
 from common import proves_send_and_assert_command
 from fprime_gds.common.data_types.event_data import EventData
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
+
+pytestmark = [pytest.mark.requires_battery]
 
 ina219SysManager = "ReferenceDeployment.ina219SysManager"
 ina219SolManager = "ReferenceDeployment.ina219SolManager"

--- a/PROVESFlightControllerReference/test/int/rtc_test.py
+++ b/PROVESFlightControllerReference/test/int/rtc_test.py
@@ -102,6 +102,11 @@ def uplink_sequence_and_await_completion(
 def test_01_time_set(fprime_test_api: IntegrationTestAPI, start_gds):
     """Test that we can set the time"""
 
+    # Sync the RTC to the test runner's clock first so the "previous time"
+    # reported by the next TIME_SET is known (a fresh boot starts at 2000-01-01)
+    set_time(fprime_test_api)
+    fprime_test_api.clear_histories()
+
     # Set time to Curiosity landing on Mars (7 minutes of terror! https://youtu.be/Ki_Af_o9Q9s)
     curiosity_landing = datetime(2012, 8, 6, 5, 17, 57, tzinfo=timezone.utc)
     set_time(fprime_test_api, curiosity_landing)
@@ -126,18 +131,14 @@ def test_01_time_set(fprime_test_api: IntegrationTestAPI, start_gds):
     event_time = datetime.fromtimestamp(fp_time.seconds, tz=timezone.utc)
 
     # Assert previously set time is within 30 seconds of now
-    pytest.approx(previously_set_time, abs=timedelta(seconds=30)) == datetime.now(
-        timezone.utc
-    )
+    assert abs(previously_set_time - datetime.now(timezone.utc)) <= timedelta(
+        seconds=30
+    ), f"Previous time {previously_set_time} should be within 30s of now"
 
     # Assert event time is within 30 seconds of curiosity landing
-    pytest.approx(event_time, abs=timedelta(seconds=30)) == curiosity_landing
-
-    # Fetch event data
-    result: EventData = fprime_test_api.assert_event(f"{rtcManager}.TimeSet", timeout=2)
-
-    # Assert time is within 30 seconds of now
-    pytest.approx(event_time, abs=timedelta(seconds=30)) == datetime.now(timezone.utc)
+    assert abs(event_time - curiosity_landing) <= timedelta(seconds=30), (
+        f"Event time {event_time} should be within 30s of {curiosity_landing}"
+    )
 
 
 @pytest.mark.uart_only(

--- a/PROVESFlightControllerReference/test/int/rtc_test.py
+++ b/PROVESFlightControllerReference/test/int/rtc_test.py
@@ -126,16 +126,18 @@ def test_01_time_set(fprime_test_api: IntegrationTestAPI, start_gds):
     event_time = datetime.fromtimestamp(fp_time.seconds, tz=timezone.utc)
 
     # Assert previously set time is within 30 seconds of now
-    pytest.approx(previously_set_time, abs=30) == datetime.now(timezone.utc)
+    pytest.approx(previously_set_time, abs=timedelta(seconds=30)) == datetime.now(
+        timezone.utc
+    )
 
     # Assert event time is within 30 seconds of curiosity landing
-    pytest.approx(event_time, abs=30) == curiosity_landing
+    pytest.approx(event_time, abs=timedelta(seconds=30)) == curiosity_landing
 
     # Fetch event data
     result: EventData = fprime_test_api.assert_event(f"{rtcManager}.TimeSet", timeout=2)
 
     # Assert time is within 30 seconds of now
-    pytest.approx(event_time, abs=30) == datetime.now(timezone.utc)
+    pytest.approx(event_time, abs=timedelta(seconds=30)) == datetime.now(timezone.utc)
 
 
 @pytest.mark.uart_only(

--- a/PROVESFlightControllerReference/test/int/tmp112_test.py
+++ b/PROVESFlightControllerReference/test/int/tmp112_test.py
@@ -15,6 +15,8 @@ from fprime_gds.common.models.serialize.numerical_types import F32Type
 from fprime_gds.common.models.serialize.time_type import TimeType
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
 
+pytestmark = [pytest.mark.requires_face]
+
 tmp112Face0Manager = "ReferenceDeployment.tmp112Face0Manager"
 
 

--- a/PROVESFlightControllerReference/test/int/veml6031_test.py
+++ b/PROVESFlightControllerReference/test/int/veml6031_test.py
@@ -13,6 +13,8 @@ from fprime_gds.common.models.serialize.numerical_types import F32Type
 from fprime_gds.common.models.serialize.time_type import TimeType
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
 
+pytestmark = [pytest.mark.requires_face]
+
 veml6031Face0Manager = "ReferenceDeployment.veml6031Face0Manager"
 
 

--- a/PROVESFlightControllerReference/test/int/watchdog_test.py
+++ b/PROVESFlightControllerReference/test/int/watchdog_test.py
@@ -87,6 +87,7 @@ def test_02_system_stays_running_with_watchdog(
     )
 
 
+@pytest.mark.requires_watchdog_jumper
 def test_03_system_reboots_without_watchdog(
     fprime_test_api: IntegrationTestAPI, start_gds
 ):

--- a/prj.conf
+++ b/prj.conf
@@ -17,8 +17,13 @@ CONFIG_REBOOT=y
 CONFIG_UART_INTERRUPT_DRIVEN=y
 
 #### Serial and I/O ####
-CONFIG_CONSOLE=y
-CONFIG_UART_CONSOLE=y
+# The F' downlink shares cdc_acm_uart0 with the Zephyr console. Keeping the UART
+# console on means printk/Os::Console text interleaves with the binary TM frames
+# and desyncs the GDS deframer. Disable the UART console so the F' UART carries
+# frames only; F' still drives the device directly via comDriver.
+CONFIG_CONSOLE=n
+CONFIG_UART_CONSOLE=n
+CONFIG_PRINTK=n
 CONFIG_SERIAL=y
 CONFIG_GPIO=y
 CONFIG_LED=y
@@ -48,8 +53,6 @@ CONFIG_DYNAMIC_THREAD_STACK_SIZE=4096
 CONFIG_THREAD_STACK_INFO=y
 CONFIG_RING_BUFFER=y
 
-CONFIG_PRINTK=y
-CONFIG_UART_CONSOLE=y
 CONFIG_COMMON_LIBC_MALLOC=y
 
 CONFIG_SENSOR=y

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,10 @@ markers =
     uart_only: marks tests that sever the RF link (resets, TRANSMIT toggle) and should only be run when connected via UART
     sync_sequence_number: marks the test that synchronizes the sequence number between GDS and flight software; should be run before any other tests to avoid sequence number mismatches
     format_filesystem: marks the test that formats the filesystem; should be run before any other tests to ensure a clean state
+    requires_face: marks tests that require a face board (TMP112 / VEML6031 / DRV2605 sensors) to be plugged in; skip on a bare flight controller
+    requires_antenna: marks tests that require the antenna board to be plugged in and the burnwire capacitor installed; skip on a bare flight controller
+    requires_battery: marks tests that require the battery board connected with power flowing from the battery terminals; skip on a bare flight controller
+    requires_watchdog_jumper: marks tests that require the JP6 watchdog jumper to be bridged so the watchdog can reset the MCU; skip when JP6 is open
 filterwarnings =
     ignore::DeprecationWarning:yamcs\..*
     ignore::DeprecationWarning:google\.protobuf\..*

--- a/scripts/check_console_disabled.py
+++ b/scripts/check_console_disabled.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""check_console_disabled.py:
+
+Guard test for CI. Fails if the Zephyr UART console is enabled in the built
+firmware configuration.
+
+Background: the F' downlink and the Zephyr console share the same USB CDC ACM
+device (cdc_acm_uart0). When the console is enabled, printk / Os::Console text
+is interleaved with the binary CCSDS TM frames on that UART, which desyncs the
+GDS deframer so no telemetry or command acks can be parsed. The console must
+therefore stay disabled so the downlink UART carries frames only.
+
+This inspects the generated Kconfig output (build-fprime-automatic-zephyr/
+zephyr/.config) rather than prj.conf, so it also catches the console being
+re-enabled via a board defconfig or a Kconfig default -- i.e. the config that
+actually gets compiled.
+
+Usage:
+    python3 scripts/check_console_disabled.py [path/to/.config]
+
+Exit status:
+    0 - console is disabled (safe to merge)
+    1 - console is enabled, or the .config was not found
+"""
+
+import sys
+from pathlib import Path
+
+DEFAULT_CONFIG = Path("build-fprime-automatic-zephyr/zephyr/.config")
+
+# Symbols that, when set to y, put console text on the shared downlink UART.
+# CONFIG_UART_CONSOLE is the direct cause; CONFIG_CONSOLE is its parent and is
+# disabled by our fix, so we treat either being enabled as a regression.
+FORBIDDEN_SYMBOLS = ("CONFIG_UART_CONSOLE", "CONFIG_CONSOLE")
+
+
+def main(argv: list[str]) -> int:
+    config_path = Path(argv[1]) if len(argv) > 1 else DEFAULT_CONFIG
+
+    if not config_path.is_file():
+        print(
+            f"ERROR: {config_path} not found. Run 'make build' first so the "
+            "generated Zephyr .config exists.",
+            file=sys.stderr,
+        )
+        return 1
+
+    enabled = []
+    for line in config_path.read_text().splitlines():
+        line = line.strip()
+        for symbol in FORBIDDEN_SYMBOLS:
+            if line == f"{symbol}=y":
+                enabled.append(symbol)
+
+    if enabled:
+        print(
+            "ERROR: the Zephyr console is enabled in the built firmware "
+            f"({config_path}):",
+            file=sys.stderr,
+        )
+        for symbol in enabled:
+            print(f"    {symbol}=y", file=sys.stderr)
+        print(
+            "\nThe console shares cdc_acm_uart0 with the F' downlink. Console "
+            "output interleaves with the CCSDS TM frames and desyncs the GDS "
+            "deframer, so telemetry and command acks cannot be parsed.\n"
+            "Keep CONFIG_CONSOLE and CONFIG_UART_CONSOLE disabled in prj.conf.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: Zephyr console is disabled in {config_path} (downlink UART is frames-only)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
- Disable `CONFIG_CONSOLE`/`CONFIG_UART_CONSOLE`/`CONFIG_PRINTK` in `prj.conf`. The Zephyr console shares `cdc_acm_uart0` with the F' downlink; leaving it enabled interleaves printk/`Os::Console` text with the binary CCSDS TM frames and desyncs the GDS deframer, breaking telemetry and command acks.
- Add `scripts/check_console_disabled.py` + `make check-console-disabled`, run in the build job's CI, to fail the build if the *compiled* Zephyr `.config` shows the console re-enabled — catches regressions from a board defconfig or Kconfig default, not just direct `prj.conf` edits.
- Add pytest markers (`requires_face`, `requires_antenna`, `requires_battery`, `requires_watchdog_jumper`) for integration tests that need add-on hardware, plus a `--bare-flight-controller-board` flag to skip them, so the suite can run more easily on a bare flight controller board without a long `-m` expression:
  ```
  make test-integration PYTEST_ARGS=--bare-flight-controller-board
  ```
- Also includes a prior fix: use `timedelta` for the `pytest.approx` abs tolerance in `rtc_test`.

## Test plan
- [x] CI build job passes `check-console-disabled`
- [ ] UART integration tests run without the command/event dropouts seen previously