### PR TITLE
fix(test): rtc test_01 TypeError under pytest 9.1 (datetime approx)

### DIFF
--- a/PROVESFlightControllerReference/test/int/rtc_test.py
+++ b/PROVESFlightControllerReference/test/int/rtc_test.py
@@ -102,6 +102,11 @@ def uplink_sequence_and_await_completion(
 def test_01_time_set(fprime_test_api: IntegrationTestAPI, start_gds):
     """Test that we can set the time"""
 
+    # Sync the RTC to the test runner's clock first so the "previous time"
+    # reported by the next TIME_SET is known (a fresh boot starts at 2000-01-01)
+    set_time(fprime_test_api)
+    fprime_test_api.clear_histories()
+
     # Set time to Curiosity landing on Mars (7 minutes of terror! https://youtu.be/Ki_Af_o9Q9s)
     curiosity_landing = datetime(2012, 8, 6, 5, 17, 57, tzinfo=timezone.utc)
     set_time(fprime_test_api, curiosity_landing)
@@ -126,16 +131,14 @@ def test_01_time_set(fprime_test_api: IntegrationTestAPI, start_gds):
     event_time = datetime.fromtimestamp(fp_time.seconds, tz=timezone.utc)
 
     # Assert previously set time is within 30 seconds of now
-    pytest.approx(previously_set_time, abs=30) == datetime.now(timezone.utc)
+    assert abs(previously_set_time - datetime.now(timezone.utc)) <= timedelta(
+        seconds=30
+    ), f"Previous time {previously_set_time} should be within 30s of now"
 
     # Assert event time is within 30 seconds of curiosity landing
-    pytest.approx(event_time, abs=30) == curiosity_landing
-
-    # Fetch event data
-    result: EventData = fprime_test_api.assert_event(f"{rtcManager}.TimeSet", timeout=2)
-
-    # Assert time is within 30 seconds of now
-    pytest.approx(event_time, abs=30) == datetime.now(timezone.utc)
+    assert abs(event_time - curiosity_landing) <= timedelta(seconds=30), (
+        f"Event time {event_time} should be within 30s of {curiosity_landing}"
+    )
 
 
 @pytest.mark.uart_only(


### PR DESCRIPTION
## Problem

Integration tests on branches cut from `main` fail intermittently in `test_01_time_set`:

```
FAILED PROVESFlightControllerReference/test/int/rtc_test.py::test_01_time_set
TypeError: absolute tolerance for datetime/timedelta must be a timedelta, got int
```

(e.g. [run 29165181551](https://github.com/Open-Source-Space-Foundation/proves-core-reference/actions/runs/29165181551) on `feat/psram-v5d`.)

## Root cause

`test_01_time_set` compares **datetimes** with `pytest.approx(..., abs=30)` — an **int** tolerance. pytest 9.1 added first-class datetime support to `approx` and now requires the tolerance to be a `timedelta`, raising `TypeError` otherwise. CI installs pytest unpinned, so runs that resolve pytest ≥ 9.1 fail while runs that resolve 8.3.3 pass — which is why the breakage appears branch-by-branch while `main`'s last run (pre-drift) is green.

On old pytest these lines were silently meaningless anyway: the `==` results were **never asserted**, so the test validated nothing.

## Fix

- Replace `pytest.approx` on datetimes with plain `abs(a - b) <= timedelta(seconds=30)` assertions — correct on every pytest version, and now actually asserted.
- Sync the RTC to the runner clock at test start so the "previous time within 30 s of now" assertion holds on a fresh boot (the RTC powers up at 2000-01-01 — visible as `1999-12-31` EVR timestamps in CI logs before this test runs).
- Remove the copy-paste block that re-fetched the same `TimeSet` event and compared a stale variable against "now".

## Related, not addressed here

- The `await_event` calls in tests 05–10 never assert (they return `None` on timeout), and test_10 leaves an alarm armed — PR #407 already covers that ground.
- Pinning CI Python deps (PR #431) would prevent this class of drift entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)