### PR TITLE
fix(RtcManager): surface seconds carry from RtcHelper::rescaleUseconds

### DIFF
--- a/PROVESFlightControllerReference/Components/Drv/RtcManager/RtcHelper.cpp
+++ b/PROVESFlightControllerReference/Components/Drv/RtcManager/RtcHelper.cpp
@@ -11,7 +11,8 @@ namespace Drv {
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-RtcHelper ::RtcHelper() {}
+RtcHelper ::RtcHelper()
+    : m_initialized(false), m_last_seen_seconds(0), m_useconds_offset(0), m_last_raw_useconds(0), m_wrap_count(0) {}
 
 RtcHelper ::~RtcHelper() {}
 
@@ -19,23 +20,28 @@ RtcHelper ::~RtcHelper() {}
 // Public helper methods
 // ----------------------------------------------------------------------
 
-std::uint32_t RtcHelper ::rescaleUseconds(std::uint32_t current_seconds, std::uint32_t current_useconds) {
-    // Update offset if a new second has been observed
-    if (this->m_last_seen_seconds != current_seconds) {
+RescaledTime RtcHelper ::rescaleUseconds(std::uint32_t current_seconds, std::uint32_t current_useconds) {
+    // Start a new bucket on the first call, or if a new RTC second has been observed. current_useconds
+    // may cycle past 1,000,000 multiple times while current_seconds is unchanged (the RTC only updates
+    // once per real second, or slower if the read lags), so wraps are tracked cumulatively against the
+    // raw value seen on the previous call rather than corrected once against the fixed offset.
+    if (!this->m_initialized || this->m_last_seen_seconds != current_seconds) {
+        this->m_initialized = true;
         this->m_last_seen_seconds = current_seconds;
         this->m_useconds_offset = current_useconds;
+        this->m_last_raw_useconds = current_useconds;
+        this->m_wrap_count = 0;
+    } else if (current_useconds < this->m_last_raw_useconds) {
+        this->m_wrap_count++;
     }
+    this->m_last_raw_useconds = current_useconds;
 
-    // Handle wrap around
-    if (current_useconds < this->m_useconds_offset) {
-        current_useconds += 1000000;
-    }
+    // Total elapsed useconds since m_useconds_offset was set, including any full cycles counted above.
+    const std::uint32_t elapsed = (current_useconds + this->m_wrap_count * 1000000) - this->m_useconds_offset;
 
-    // Compute delta
-    std::uint32_t delta = current_useconds - this->m_useconds_offset;
-
-    // FPrime expects microseconds in the range [0, 999999]
-    return delta % 1000000;
+    // FPrime expects microseconds in the range [0, 999999]. Any whole seconds in elapsed overflowed
+    // out of the useconds field and must be reported back so the caller can carry them into seconds.
+    return RescaledTime{elapsed % 1000000, elapsed / 1000000};
 }
 
 }  // namespace Drv

--- a/PROVESFlightControllerReference/Components/Drv/RtcManager/RtcHelper.hpp
+++ b/PROVESFlightControllerReference/Components/Drv/RtcManager/RtcHelper.hpp
@@ -9,6 +9,13 @@
 
 namespace Drv {
 
+//! Result of rescaling useconds: the rescaled microseconds, plus any whole seconds that
+//! overflowed out of the microseconds field and must be added to the caller's seconds value.
+struct RescaledTime {
+    std::uint32_t useconds;       //!< The rescaled microseconds, always in [0, 999999]
+    std::uint32_t seconds_carry;  //!< Whole seconds that overflowed out of useconds
+};
+
 class RtcHelper {
   public:
     // ----------------------------------------------------------------------
@@ -30,7 +37,14 @@ class RtcHelper {
     //! We have two clocks: the RTC clock which provides seconds, and the system uptime clock which provides
     //! milliseconds since boot. We use the initial offset of the system uptime clock when the RTC time is first read
     //! to ensure that the microseconds portion of the time is always increasing.
-    std::uint32_t rescaleUseconds(
+    //!
+    //! Because current_seconds only advances once per real second (or slower, if the RTC read lags),
+    //! current_useconds can cycle past 1,000,000 more than once while current_seconds is unchanged.
+    //! Each cycle is tracked so total elapsed time since current_seconds was last observed can exceed
+    //! 1,000,000us; the whole-second part is reported via seconds_carry so the caller can add it to
+    //! current_seconds instead of silently losing it, which would otherwise make the returned time
+    //! appear to go backward.
+    RescaledTime rescaleUseconds(
         std::uint32_t current_seconds,  //<! The epoch seconds from the RTC
         std::uint32_t current_useconds  //<! The microseconds since boot from the system uptime clock
     );
@@ -40,8 +54,11 @@ class RtcHelper {
     // Private member variables
     // ----------------------------------------------------------------------
 
+    bool m_initialized;                 //!< Whether a first sample has been observed yet
     std::uint32_t m_last_seen_seconds;  //!< The last seen seconds value from the RTC
     std::uint32_t m_useconds_offset;    //!< The offset to apply to microseconds to ensure monotonicity
+    std::uint32_t m_last_raw_useconds;  //!< The raw useconds seen on the previous call, for wrap detection
+    std::uint32_t m_wrap_count;         //!< Cycles of current_useconds observed since m_useconds_offset was set
 };
 
 }  // namespace Drv

--- a/PROVESFlightControllerReference/Components/Drv/RtcManager/RtcManager.cpp
+++ b/PROVESFlightControllerReference/Components/Drv/RtcManager/RtcManager.cpp
@@ -85,9 +85,11 @@ void RtcManager ::timeGetPort_handler(FwIndexType portNum, Fw::Time& time) {
     }
     this->log_CONSOLE_RtcInvalidTime_ThrottleClear();
 
-    // Set FPrime time object
-    time.set(TimeBase::TB_WORKSTATION_TIME, 0, seconds_real_time,
-             this->m_rtcHelper.rescaleUseconds(seconds_real_time, useconds_since_boot));
+    // Set FPrime time object. Any seconds_carry from the rescale must be added to seconds_real_time,
+    // or a useconds wrap that overflows a full second would otherwise make the reported time appear
+    // to go backward (seconds_real_time only advances once per real second at RTC hardware resolution).
+    const Drv::RescaledTime rescaled = this->m_rtcHelper.rescaleUseconds(seconds_real_time, useconds_since_boot);
+    time.set(TimeBase::TB_WORKSTATION_TIME, 0, seconds_real_time + rescaled.seconds_carry, rescaled.useconds);
 }
 
 // ----------------------------------------------------------------------

--- a/PROVESFlightControllerReference/test/unit-tests/test_RtcManager_RtcHelper.cpp
+++ b/PROVESFlightControllerReference/test/unit-tests/test_RtcManager_RtcHelper.cpp
@@ -2,40 +2,72 @@
 
 #include "PROVESFlightControllerReference/Components/Drv/RtcManager/RtcHelper.hpp"
 
+using Drv::RescaledTime;
 using Drv::RtcHelper;
 
 TEST(RtcHelperTest, BasicRescaleUseconds) {
     RtcHelper helper;
 
     // First sample establishes offset, returns 0
-    EXPECT_EQ(helper.rescaleUseconds(0U, 0U), 0U);
+    EXPECT_EQ(helper.rescaleUseconds(0U, 0U).useconds, 0U);
 
     // Move forward within same second
-    EXPECT_EQ(helper.rescaleUseconds(0U, 123456U), 123456U);
+    EXPECT_EQ(helper.rescaleUseconds(0U, 123456U).useconds, 123456U);
 
     // Move to next second, offset updates
-    EXPECT_EQ(helper.rescaleUseconds(1U, 250U), 0U);
+    EXPECT_EQ(helper.rescaleUseconds(1U, 250U).useconds, 0U);
 
     // Small forward step
-    EXPECT_EQ(helper.rescaleUseconds(1U, 500U), 250U);
+    EXPECT_EQ(helper.rescaleUseconds(1U, 500U).useconds, 250U);
+}
+
+TEST(RtcHelperTest, BasicRescaleUsecondsHasNoSecondsCarry) {
+    RtcHelper helper;
+
+    EXPECT_EQ(helper.rescaleUseconds(0U, 0U).seconds_carry, 0U);
+    EXPECT_EQ(helper.rescaleUseconds(0U, 123456U).seconds_carry, 0U);
+    EXPECT_EQ(helper.rescaleUseconds(1U, 250U).seconds_carry, 0U);
+    EXPECT_EQ(helper.rescaleUseconds(1U, 500U).seconds_carry, 0U);
 }
 
 TEST(RtcHelperTest, WrapAroundAtOneSecond) {
     RtcHelper helper;
 
     // Prime offset near the end of the second
-    EXPECT_EQ(helper.rescaleUseconds(0U, 999999U), 0U);
+    EXPECT_EQ(helper.rescaleUseconds(0U, 999999U).useconds, 0U);
 
-    // Wrap from 999999 -> 85: forward delta is 86 microseconds
-    EXPECT_EQ(helper.rescaleUseconds(0U, 85U), 86U);
+    // Wrap from 999999 -> 85: only 86 microseconds of real time passed (the offset was primed
+    // right at the edge of the cycle), so no whole second has elapsed yet
+    const RescaledTime result = helper.rescaleUseconds(0U, 85U);
+    EXPECT_EQ(result.useconds, 86U);
+    EXPECT_EQ(result.seconds_carry, 0U);
 }
 
 TEST(RtcHelperTest, WrapAroundAtU32Max) {
     RtcHelper helper;
 
     // Prime offset near the max U32 value
-    EXPECT_EQ(helper.rescaleUseconds(0U, 4294967290U), 0U);
+    EXPECT_EQ(helper.rescaleUseconds(0U, 4294967290U).useconds, 0U);
 
-    // Wrap from 4294967290 -> 5: forward delta is 11 microseconds
-    EXPECT_EQ(helper.rescaleUseconds(0U, 5U), 11U);
+    // Wrap from 4294967290 -> 5: uint32 arithmetic wraps through the full 32-bit space (not just
+    // the 1,000,000us domain), producing a large elapsed value that folds into a carry
+    const RescaledTime result = helper.rescaleUseconds(0U, 5U);
+    EXPECT_EQ(result.useconds, 11U);
+    EXPECT_EQ(result.seconds_carry, 1U);
+}
+
+TEST(RtcHelperTest, StaleRtcSecondAcrossMultipleWraps) {
+    RtcHelper helper;
+
+    // RTC second is stale across a burst of reads while uptime keeps advancing, wrapping twice
+    EXPECT_EQ(helper.rescaleUseconds(0U, 999999U).useconds, 0U);
+
+    const RescaledTime one_wrap = helper.rescaleUseconds(0U, 999998U);
+    EXPECT_EQ(one_wrap.useconds, 999999U);
+    EXPECT_EQ(one_wrap.seconds_carry, 0U);
+
+    // Uptime wraps a second time while current_seconds (0) still hasn't ticked over
+    const RescaledTime two_wraps = helper.rescaleUseconds(0U, 999997U);
+    EXPECT_EQ(two_wraps.useconds, 999998U);
+    EXPECT_EQ(two_wraps.seconds_carry, 1U);
 }


### PR DESCRIPTION
## Problem

- [ ] Human review required. I really thought the "time going backward" stuff was behind us but maybe it's just way less likely?

`RtcHelper::rescaleUseconds` normalizes the sub-second `useconds` field but silently discards any whole seconds that overflow out of it — it only corrects for a single wrap against a fixed per-second offset. When a burst of RTC reads lands on the same stale RTC-reported second (the RV3028 is 1 Hz) while the underlying uptime counter wraps more than once, the returned `(seconds, useconds)` pair can appear to go backward in time.

This desynced the GDS test API's out-of-order event detector and broke `test_03_time_not_set_event` in CI:
[run 29167497662/job/86583350942](https://github.com/Open-Source-Space-Foundation/proves-core-reference/actions/runs/29167497662/job/86583350942)

```
2(0)-1783803292:999000  DayValidationFailed
2(0)-1783803292:001000  HourValidationFailed   <- same raw "seconds", useconds went backward
```

Root cause and analysis documented in #436.

## Fix

- `rescaleUseconds` now tracks wraps cumulatively across calls (instead of a single fixed-offset correction) and returns a `RescaledTime{useconds, seconds_carry}` struct instead of a bare `uint32_t`.
- `RtcManager::timeGetPort_handler` adds `seconds_carry` into `seconds_real_time` before calling `time.set()`, so the reported time stays monotonic even when a burst of reads spans multiple sub-second wraps.
- Also fixes a latent bug found along the way: `RtcHelper`'s constructor never initialized its offset-tracking members, relying on uninitialized memory happening to differ from the first real input.

## Testing

- Extended `test_RtcManager_RtcHelper.cpp` to assert on `seconds_carry`, plus a new `StaleRtcSecondAcrossMultipleWraps` test covering the multi-wrap scenario from the CI failure.
- `cmake --build build-gtest && ctest --test-dir build-gtest` — all 4 unit test binaries pass.
- `pre-commit run` (clang-format, cpplint, codespell) passes clean on the changed files.
- Not yet verified against real UART hardware — marking as draft pending that + review.

Fixes #436