### PR TITLE
Add repository and submodule reset step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Reset repository and submodules to original state
+        run: |
+          git clean -fd
+          git reset --hard
+          git submodule foreach git clean -fd
+          git submodule foreach git reset --hard
+
       - name: Download bin tools
         if: steps.cache-bin.outputs.cache-hit != 'true'
         run: |
@@ -223,7 +230,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: "17"
 
       - name: Start YAMCS Stack
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,11 @@ jobs:
 
       - name: Reset repository and submodules to original state
         run: |
-          git clean -fd
+          git submodule update --init --recursive
+          git clean -dfX
           git reset --hard
-          git submodule foreach git clean -fd
-          git submodule foreach git reset --hard
+          git submodule foreach --recursive git clean -dfX
+          git submodule foreach --recursive git reset --hard
 
       - name: Download bin tools
         if: steps.cache-bin.outputs.cache-hit != 'true'


### PR DESCRIPTION
Adds a step in the build workflow to reset the repository and submodules to their original states to ensure changes from other prs don't linger