### PR TITLE
Restore sync-sequence-number Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,11 @@ test-integration: uv ## Run integration tests (set TEST=<name|file.py> or pass t
 %:
 	@:
 
+.PHONY: sync-sequence-number
+sync-sequence-number: uv ## Synchronize GDS/flight sequence number
+	@echo "Synchronizing sequence number"
+	@$(UV_RUN) pytest PROVESFlightControllerReference/test/int/sync_sequence_number_test.py --deployment build-artifacts/zephyr/fprime-zephyr-deployment
+
 .PHONY: test-interactive
 test-interactive: fprime-venv ## Run interactive test selection (set ARGS for CLI mode, e.g., ARGS="--all --cycles 10")
 	@$(UV_RUN) python PROVESFlightControllerReference/test/run_interactive_tests.py $(ARGS)


### PR DESCRIPTION
### Motivation
- Reintroduce the convenience Makefile target for synchronizing the authentication sequence number between GDS and the flight software so users can run `make sync-sequence-number` to perform the operation without remembering a pytest command.

### Description
- Add a `.PHONY: sync-sequence-number` entry and a `sync-sequence-number` target to `Makefile` which echoes a message and runs `pytest PROVESFlightControllerReference/test/int/sync_sequence_number_test.py --deployment build-artifacts/zephyr/fprime-zephyr-deployment` via the repository `uv` helper.

### Testing
- Verified the target command expansion with `make -n sync-sequence-number` which printed the expected `uv` pytest invocation.
- Ran `make fmt` (pre-commit hooks) to ensure formatting and lint checks passed.
- Ran `git diff --check` to confirm there were no whitespace or diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bb24eb4808326b6cdc1f5c1067c74)