### PR TITLE
ci: restore build-job reset step (dropped by #421), sparing the west workspace clones

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Reset repository and submodules to original state
+        # Restores the latent-state protection from #441 (accidentally dropped
+        # by the Zephyr 4.4.1 upgrade in #421). Unlike the original step, the
+        # west-managed Zephyr workspace is excluded from the top-level clean and
+        # instead has each module's working tree reset in place: carried
+        # patches (patches/*.patch) are applied into these trees, so they must
+        # start pristine every run, but deleting the clones would force a full
+        # re-fetch of Zephyr and all modules on every build.
+        run: |
+          git submodule update --init --recursive
+          git clean -dfX -e lib/zephyr-workspace
+          git reset --hard
+          git submodule foreach --recursive git clean -dfX
+          git submodule foreach --recursive git reset --hard
+          find lib/zephyr-workspace -mindepth 1 -maxdepth 4 -name .git 2>/dev/null | while read -r g; do
+            d=$(dirname "$g")
+            git -C "$d" reset --hard
+            git -C "$d" clean -fdx
+          done
+
       - name: Download bin tools
         if: steps.cache-bin.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,24 +46,17 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Reset repository and submodules to original state
-        # Restores the latent-state protection from #441 (accidentally dropped
-        # by the Zephyr 4.4.1 upgrade in #421). Unlike the original step, the
-        # west-managed Zephyr workspace is excluded from the top-level clean and
-        # instead has each module's working tree reset in place: carried
-        # patches (patches/*.patch) are applied into these trees, so they must
-        # start pristine every run, but deleting the clones would force a full
-        # re-fetch of Zephyr and all modules on every build.
         run: |
-          git submodule update --init --recursive
           git clean -dfX -e lib/zephyr-workspace
           git reset --hard
-          git submodule foreach --recursive git clean -dfX
+          git submodule foreach --recursive git clean -fdx
           git submodule foreach --recursive git reset --hard
-          find lib/zephyr-workspace -mindepth 1 -maxdepth 4 -name .git 2>/dev/null | while read -r g; do
+          find lib/zephyr-workspace -mindepth 1 -name .git 2>/dev/null | while read -r g; do
             d=$(dirname "$g")
             git -C "$d" reset --hard
             git -C "$d" clean -fdx
           done
+          git submodule update --init --recursive
 
       - name: Download bin tools
         if: steps.cache-bin.outputs.cache-hit != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ make build
 - Command: `make generate`
 
 ### Linting & Formatting
+
 **IMPORTANT**: The linter must be run before every commit.
+
 ```bash
 # Run all pre-commit checks (REQUIRED before committing)
 make fmt
@@ -108,7 +110,6 @@ make test-unit
 ```
 
 Uses CMake/CTest. Unit tests are in `PROVESFlightControllerReference/test/unit-tests/`.
-
 
 **Test Framework Details**:
 
@@ -472,10 +473,12 @@ When creating components that need hardware access:
 The project includes a comprehensive set of custom F Prime components organized by function:
 
 **ADCS & Control**:
+
 - **ADCS**: Attitude determination and control system
 - **DetumbleManager**: Magnetic detumble control
 
 **Communication**:
+
 - **AmateurRadio**: Amateur radio (LoRa) management
 - **SBand**: S-Band radio management
 - **ComCcsdsLora / ComCcsdsSband / ComCcsdsUart**: CCSDS framing layers for each link
@@ -483,6 +486,7 @@ The project includes a comprehensive set of custom F Prime components organized 
 - **PayloadCom**: Payload communication interface
 
 **Core System**:
+
 - **ModeManager**: Spacecraft operating mode management
 - **StartupManager**: Startup sequence and boot count
 - **ResetManager**: System reset and watchdog management
@@ -491,6 +495,7 @@ The project includes a comprehensive set of custom F Prime components organized 
 - **BootloaderTrigger**: Bootloader mode entry for firmware updates
 
 **Hardware Drivers (Drv/)**:
+
 - **ImuManager**: LSM6DSO 6-axis IMU sensor management
 - **Drv2605Manager**: Haptic feedback driver
 - **Ina219Manager**: INA219 current/power monitor
@@ -499,6 +504,7 @@ The project includes a comprehensive set of custom F Prime components organized 
 - **Veml6031Manager**: VEML6031 ambient light sensor
 
 **Hardware Control**:
+
 - **AntennaDeployer**: Antenna deployment mechanism
 - **Burnwire**: Burnwire deployment control
 - **CameraHandler**: Camera management
@@ -507,12 +513,14 @@ The project includes a comprehensive set of custom F Prime components organized 
 - **ThermalManager**: Thermal monitoring and control
 
 **Storage**:
+
 - **FlashWorker**: Flash memory read/write management
 - **FsFormat**: Filesystem formatting
 - **FsSpace**: Filesystem space monitoring
 - **NullPrmDb**: No-op parameter database (for systems without persistent storage)
 
 **Security**:
+
 - **Authenticate**: HMAC-based command authentication
 - **ProvesRouter**: Routes authenticated vs. unauthenticated commands
 
@@ -593,6 +601,10 @@ Firmware is signed with MCUBoot for secure boot. The signing key is at `keys/pro
 ```bash
 make build-mcuboot       # Build firmware with MCUBoot signing
 ```
+
+### CI File Edits
+
+Avoid adding giant expanatory comment blocks in `ci.yaml` for changes. Be very conservative with code comments in this file, only add them if they're necessary to understand what a line of the workflow does, and even then, keep them very concise.
 
 ## Trust These Instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -604,7 +604,7 @@ make build-mcuboot       # Build firmware with MCUBoot signing
 
 ### CI File Edits
 
-Avoid adding giant expanatory comment blocks in `ci.yaml` for changes. Be very conservative with code comments in this file, only add them if they're necessary to understand what a line of the workflow does, and even then, keep them very concise.
+Avoid adding giant explanatory comment blocks in `ci.yaml` for changes. Be very conservative with code comments in this file; only add them if they're necessary to understand what a line of the workflow does, and even then, keep them very concise.
 
 ## Trust These Instructions
 


### PR DESCRIPTION
## Summary

- **Restores the latent-state protection from #441**, which was accidentally removed from `main` by the Zephyr 4.4.1 upgrade (#421, commit 606eb0a) — since July 19 the self-hosted build job has had no reset step at all, re-exposing the patched-submodule state leakage #441 fixed.
- **Spares the west-managed Zephyr workspace from the top-level `git clean -dfX`** (`-e lib/zephyr-workspace`). The gitignored west module clones (zephyr, cmsis, hal_rpi_pico, mbedtls, …) are never tracked content; wiping them forces a full re-fetch on every build.
- **Resets each west module's working tree in place instead** (`git reset --hard && git clean -fdx` per clone). Carried patches — `patches/*.patch` today, plus the usp_zephyr/usp/zephyr patch sets landing in #439 — are applied into these trees, so they must start pristine every run or `west update` revision bumps land on dirty trees and the patch targets fail with 'Cannot apply'. Resetting the working tree gives the pristine guarantee while keeping the git object stores, so `west update` stays an incremental fetch (~86 s floor) instead of a re-clone (~4–5 min), even across `west.yml` revision bumps like 4.3 → 4.4.1.

Observed 'Setup Zephyr' timings on deathstar: 86–89 s steady-state incremental, 239–300 s when the runner crosses `west.yml` changes (4.4.1 upgrade, #439's new USP modules). This change keeps the job at the incremental floor while restoring run-to-run hygiene.

## Test plan

- [ ] CI build job green on this PR (first run may pay a one-time fetch)
- [ ] Re-run the build job to confirm 'Setup Zephyr' stays at the ~86 s incremental floor
- [ ] Verify `git status` inside `lib/fprime` and the west modules is clean at the start of the run (patch state from the previous run is reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)