### PR TITLE
fix(ram): shrink mbedTLS static heap 32K->8K to widen malloc arena margin

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -84,7 +84,10 @@ CONFIG_MBEDTLS=y
 CONFIG_MBEDTLS_BUILTIN=y
 CONFIG_MBEDTLS_PSA_CRYPTO_C=y
 CONFIG_MBEDTLS_ENABLE_HEAP=y
-CONFIG_MBEDTLS_HEAP_SIZE=32767
+# Only PSA HMAC-SHA256 is used (no TLS sessions); measured working set is
+# ~1-2 KiB, so 8 KiB keeps >=4x headroom while returning 24 KiB of SRAM to
+# the libc malloc arena that BufferManager setup allocates from at boot.
+CONFIG_MBEDTLS_HEAP_SIZE=8192
 CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN=4096
 # HMAC-SHA256 for TcSecurityDeframer packet authentication
 CONFIG_PSA_WANT_KEY_TYPE_HMAC=y


### PR DESCRIPTION
## Summary

Reduces `CONFIG_MBEDTLS_HEAP_SIZE` from 32767 to 8192, returning 24 KiB of SRAM to the libc malloc arena.

The 32767-byte value dates to the original Authenticate router bring-up (#139) with no sizing rationale — Zephyr's Kconfig default for this option is 512 B. This tree uses mbedTLS only for PSA HMAC-SHA256 (TcSecurityDeframer uplink authentication); there are no TLS sessions.

## Why it matters: RAM margin is currently razor-thin

With `CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=-1`, the malloc arena is exactly the SRAM left after static allocation, and F´ boot-time setup (BufferManagers, component queues) draws ~162 KiB from it deterministically. HWIL measurements on a v5e (feat/usp-radio tree, where the arena is 173,272 B):

- **Free heap at boot: 11,504 B (6.6% of arena)** — verified by live sys_heap walk over the debug probe; byte-exact across two boards.
- **Exhaustion boundary confirmed by ballast flashes: +8 KiB of static growth still boots; +16 KiB reproduces a hard boot loop** (BufferManager `FW_ASSERT` → FatalHandler reboot, ~3.75 s cycle). The wall is exactly the free margin — no slack.
- Radio operation allocates zero heap beyond boot, so boot margin is the whole margin.

## Measured mbedTLS usage (HWIL, `CONFIG_MBEDTLS_MEMORY_DEBUG`)

Peak mbedTLS heap usage: **368 bytes** (7 allocations, all at PSA init — the per-command HMAC path allocates nothing). 8192 retains **~22× headroom**. Verified stable boot plus an 85-command authenticated storm (NO_OP, SET_LEVEL toggles, PRM_SET/SAVE cycles) with zero errors on this exact config.

## Effect

On the current main-line v5e image this raises boot heap margin by 8 KiB; on the USP branch it lifts margin from ~11.5 KiB (6.6%) to ~19.7 KiB (11.6%). Further reserves if ever needed: dynamic thread-stack pool sizing (largest single consumer at 100 KiB for 25×4 KiB stacks vs 22 live threads) and comms buffer counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)