### PR TITLE
fix(ram): carry TlmPacketizer I16 packetOffset patch (−27.5 KiB RAM Reduction)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,13 @@ repos:
   rev: v5.0.0
   hooks:
     - id: trailing-whitespace
+      # patches/*.patch are machine-generated diffs applied via `git apply`;
+      # their context/removed lines must byte-match the real upstream files,
+      # which can legitimately have trailing whitespace. Stripping it here
+      # silently breaks patch application.
+      exclude: ^patches/
     - id: end-of-file-fixer
+      exclude: ^patches/
     - id: check-yaml
       exclude: ^mkdocs\.yml$
     - id: check-json

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,17 @@ help: ## Display this help.
 submodules: ## Initialize and update git submodules
 	@git submodule foreach --recursive 'git checkout -- . && git clean -fd' || true
 	@git submodule update --init --recursive
+	@echo "Applying fprime TlmPacketizer I16 packetOffset patch (upstream candidate)..."
+	@cd lib/fprime && \
+		if git apply --check ../../patches/fprime-tlmpacketizer-i16-offset.patch 2>/dev/null; then \
+			git apply ../../patches/fprime-tlmpacketizer-i16-offset.patch && \
+			echo "✓ Applied TlmPacketizer I16 packetOffset patch"; \
+		elif git apply --reverse --check ../../patches/fprime-tlmpacketizer-i16-offset.patch 2>/dev/null; then \
+			echo "⚠ Patch already applied"; \
+		else \
+			echo "❌ Error: Unable to apply TlmPacketizer I16 patch. Run 'cd lib/fprime && git status' to check."; \
+			exit 1; \
+		fi
 
 export VIRTUAL_ENV ?= $(shell pwd)/fprime-venv
 .PHONY: fprime-venv

--- a/patches/README.md
+++ b/patches/README.md
@@ -2,6 +2,24 @@
 
 This directory contains patches that are automatically applied to git submodules during the build process.
 
+## fprime-tlmpacketizer-i16-offset.patch
+
+Shrinks `Svc::TlmPacketizer`'s per-channel `packetOffset` array from `FwSignedSizeType`
+(64-bit) to `I16` in `lib/fprime`. The offset is a byte index into a ComBuffer-sized
+packet (or the -1 "not in this packet" sentinel), so I16 is ample; the range `FW_ASSERT`
+in `setPacketList` is tightened to the I16 max.
+
+**Why:** With this project's `MAX_PACKETIZER_CHANNELS=202` and `MAX_PACKETIZER_PACKETS=22`,
+the dense channels×packets offset matrix dominates the component: the patch shrinks the
+`tlmSend` instance from 60,480 to 33,008 B of BSS (−27,472 B), which flows 1:1 into the
+libc malloc arena (free-at-boot measured 11,504 → 38,976 B on a v5e board).
+
+**Status:** Upstream candidate for nasa/fprime; carried here until accepted.
+
+**Application:** Applied automatically by `make submodules` with a reverse-apply
+idempotency check. As with the other fprime patches, `lib/fprime` will show as modified —
+do not commit the submodule pointer.
+
 ## fprime-gds-version.patch
 
 This patch updates the `fprime-gds` version requirement in `lib/fprime/requirements.txt` from 4.1.0 to 4.1.1a2.

--- a/patches/fprime-tlmpacketizer-i16-offset.patch
+++ b/patches/fprime-tlmpacketizer-i16-offset.patch
@@ -1,0 +1,31 @@
+diff --git a/Svc/TlmPacketizer/TlmPacketizer.cpp b/Svc/TlmPacketizer/TlmPacketizer.cpp
+index 89af22e1d..ba1c68555 100644
+--- a/Svc/TlmPacketizer/TlmPacketizer.cpp
++++ b/Svc/TlmPacketizer/TlmPacketizer.cpp
+@@ -89,10 +89,10 @@ void TlmPacketizer::setPacketList(const TlmPacketizerPacketList& packetList,
+             entry.ignored = false;
+             entry.channelSize = packetList.list[pktEntry]->list[tlmEntry].size;
+             // the offset into the buffer will be the current packet length
+-            // the offset must fit within FwSignedSizeType to allow for negative values
+-            FW_ASSERT(packetLen <= static_cast<FwSizeType>(std::numeric_limits<FwSignedSizeType>::max()),
++            // the offset must fit within I16 to allow for the -1 sentinel value
++            FW_ASSERT(packetLen <= static_cast<FwSizeType>(std::numeric_limits<I16>::max()),
+                       static_cast<FwAssertArgType>(packetLen));
+-            entry.packetOffset[pktEntry] = static_cast<FwSignedSizeType>(packetLen);
++            entry.packetOffset[pktEntry] = static_cast<I16>(packetLen);
+ 
+             packetLen += entry.channelSize;
+ 
+diff --git a/Svc/TlmPacketizer/TlmPacketizer.hpp b/Svc/TlmPacketizer/TlmPacketizer.hpp
+index 7f80d76d2..ffb58fc5d 100644
+--- a/Svc/TlmPacketizer/TlmPacketizer.hpp
++++ b/Svc/TlmPacketizer/TlmPacketizer.hpp
+@@ -172,7 +172,7 @@ class TlmPacketizer final : public TlmPacketizerComponentBase, public Fw::ParamE
+         FwChanIdType id;  //!< telemetry id stored in slot
+         // Offsets into packet buffers.
+         // -1 means that channel is not in that packet
+-        FwSignedSizeType packetOffset[MAX_PACKETIZER_PACKETS];
++        I16 packetOffset[MAX_PACKETIZER_PACKETS];
+         FwSizeType channelSize;  //!< max serialized size of the channel in bytes
+         bool ignored;            //!< ignored channel id
+         bool hasValue;           //!< if the entry has received a value at least once


### PR DESCRIPTION
## What

Carries `patches/fprime-tlmpacketizer-i16-offset.patch` against `lib/fprime`, applied by `make submodules` with a reverse-apply idempotency check (same pattern as the existing fprime-yamcs patch step). The patch shrinks `Svc::TlmPacketizer`'s per-channel `packetOffset` array from `FwSignedSizeType` (64-bit) to `I16` — 3 functional lines:

- `TlmEntry::packetOffset[MAX_PACKETIZER_PACKETS]`: `FwSignedSizeType` → `I16` (`TlmPacketizer.hpp`)
- Range `FW_ASSERT` in `setPacketList` tightened to the I16 max + cast at the single assignment site (`TlmPacketizer.cpp`)

Also excludes `patches/` from the trailing-whitespace / end-of-file pre-commit hooks — patch bytes must byte-match the upstream tree or `git apply` silently breaks.

## Why

F Prime's 64-bit size-type migration leaked into a persistent dense channels × packets offset matrix. With this deployment's `MAX_PACKETIZER_CHANNELS=202` and `MAX_PACKETIZER_PACKETS=22`, the offsets alone are 202×22×8 B ≈ 35.5 KB of BSS. Offsets index into ComBuffers ≤ 256 B, so I16 (which preserves the −1 "not in this packet" sentinel and supports packets up to 32 KiB) is ample. Since our malloc arena is the SRAM left over after static allocation (`CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=-1`) and boot margin was measured at 11,504 B with a hard BufferManager-assert boot-loop past it (background: #467), this flows 1:1 into heap headroom.

## Measured (v5e reference deployment)

| Metric | Before | After | Delta |
|---|---|---|---|
| `CdhCore::tlmSend` bss | 60,480 B | 33,008 B | **−27,472 B** |
| malloc arena | 173,272 B | 200,744 B | +27,472 B |
| free heap at boot | 11,504 B | 38,976 B | **3.4×** |

The −27,472 B was reproduced in this branch's build (`nm`: `tlmSend` = 0x80f0).

## Validation

- fprime `Svc/TlmPacketizer` UT: 12/12 pass (1 pre-existing skip)
- `make test-unit`: 8/8 pass on this branch
- HWIL on a v5e flight board: stable boot, 49 channels decode sane, NO_OP round-trip and SEND_PKT (Beacon + Health) pass, live sys_heap walk measured arena 200,744 B / free-at-boot 38,976 B — matching the nm-predicted numbers exactly
- `make submodules` apply flow verified idempotent (reverse-apply check on second run)

## Status

Carried patch, pending upstream acceptance in nasa/fprime — upstreaming proposal tracked in #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
