### PR TITLE
perf(comdelay): DIVIDER=0 passes comStatus straight through (TX-done-paced downlink)

### DIFF
--- a/PROVESFlightControllerReference/Components/ComDelay/ComDelay.cpp
+++ b/PROVESFlightControllerReference/Components/ComDelay/ComDelay.cpp
@@ -38,9 +38,38 @@ void ComDelay ::parameterUpdated(FwPrmIdType id) {
 // Handler implementations for typed input ports
 // ----------------------------------------------------------------------
 
+// Image-currency marker: grep-able via `strings zephyr.elf` to verify the flashed
+// binary actually contains the divider-0 passthrough change (never trust "Verified OK").
+static volatile const char COMDELAY_DIV0_PASSTHROUGH_MARKER[] = "comdelay-div0-passthrough-20260723";
+
 void ComDelay ::comStatusIn_handler(FwIndexType portNum, Fw::Success& condition) {
-    this->m_last_status = condition;
-    this->m_last_status_valid = true;
+    // Read the divider; on invalid/uninit fall back to the default (matches run_handler).
+    Fw::ParamValid is_valid;
+    U16 current_divisor = this->paramGet_DIVIDER(is_valid);
+    if ((is_valid == Fw::ParamValid::INVALID) || (is_valid == Fw::ParamValid::UNINIT)) {
+        current_divisor = Components::DEFAULT_DIVIDER;
+    }
+
+    if (current_divisor == 0) {
+        // DIVIDER == 0 means "no delay": forward the status immediately instead of
+        // latching it for the next rate tick. This removes the rate-group quantization
+        // (one status per tick) so downlink is paced purely by radio TX-done.
+        //
+        // Threading note: ComDelay is passive, so this executes on the CALLER's thread
+        // (the radio-side comStatus source). That is safe because comStatusOut feeds an
+        // async input (ComQueue), which only enqueues a message here.
+        //
+        // Coherence with run_handler: in passthrough mode we never set
+        // m_last_status_valid, so this status cannot ALSO be emitted by run_handler
+        // (no duplication). A status latched earlier under DIVIDER > 0 is still
+        // consumed by run_handler's compare_exchange as before (no loss) if the
+        // divider is changed to 0 at runtime.
+        static_cast<void>(COMDELAY_DIV0_PASSTHROUGH_MARKER[0]);  // volatile read keeps the marker in the image
+        this->comStatusOut_out(0, condition);
+    } else {
+        this->m_last_status = condition;
+        this->m_last_status_valid = true;
+    }
 }
 
 void ComDelay ::run_handler(FwIndexType portNum, U32 context) {


### PR DESCRIPTION
## Problem

File downlink over the USP LoRa radio is throughput-capped by ComDelay: `comStatusIn_handler` only latches `m_last_status`, and `run_handler` (10 Hz via `rateGroup10Hz -> downlinkDelay.run`, topology.fpp:233) releases at most one comStatus per tick even when `DIVIDER=0` — a ~10 frames/s ceiling (~2 kB/s at 248 B frames) regardless of air rate.

## Fix

`DIVIDER == 0` -> forward `comStatusIn` to `comStatusOut` immediately (TX-done-paced, no rate-group quantization). `DIVIDER > 0` -> existing latched/tick-paced behavior unchanged.

Coherence: in passthrough mode the valid flag is never set, so a status cannot also be emitted by `run_handler` (no double emit). A status latched under `DIVIDER > 0` before a runtime switch to 0 is still consumed by `run_handler`'s `compare_exchange` (no loss). ComDelay is passive, so the forward executes on the radio-side caller thread — safe because `comStatusOut` feeds ComQueue's async input (enqueue only). A grep-able image-currency marker string is included (`comdelay-div0-passthrough-20260723`).

No existing ComDelay UT harness in the repo (CMakeLists UT block is the commented template), so no UT was added per scope; behavior was bench-validated instead.

## HWIL A/B (2026-07-23, v5e flight + GRC-USP ground, P4_GFSK_75K both ends)

Radio-only downlink path (`downlinkRepeater.CHANNEL_ENABLED=[DISABLED,ENABLED,ENABLED]`, `downlinkDelay.DIVIDER=0`), 178,704 B file via `FileDownlink.SendFile`, timed SendStarted->FileSent; flashed image currency verified by reading the marker string back from board flash (0x100b3b87).

| Run | Image | Duration | Effective B/s |
|---|---|---|---|
| baseline | latched (fork b7931b1) | 90.19 s | 1981 |
| passthrough #1 | this PR | 69.75 s | 2562 |
| passthrough #2 | this PR | 71.47 s | 2500 |

~1.28x speedup; the link is now air-rate/TX-done-limited instead of tick-limited. Received files byte-identical to baseline (identical cksum). No QueueOverflow storms (baseline itself showed one benign ComCcsdsLora QueueOverflow; passthrough runs showed none), no panics/wedges/reboots. Cycle-slip warnings rose 42 -> ~200 per run (warnings only, known under RF+TM load). Regression checks on the passthrough image: `DIVIDER=9` still tick-paces (~0.8 frame/s observed on a 3 kB partial), profile sweep P1->P2->P3->P4 + NO_OP all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Stack note (2026-07-30):** rebased onto post-#477 `feat/usp-radio` (patch-collapse; now at `c6df588`), resolving the stale base. This PR is now the **bottom of a native GitHub stack**: `feat/usp-radio` <- #475 <- #479. The passthrough unit-test coverage lives in #479 (which stacks on this branch and ports the passthrough into `ComDelayLogic`).
