### PR TITLE
perf(v5e): SX1262 SPI 125 kHz -> 4 MHz + TCXO wakeup 10 -> 5 ms (1.72x downlink)

### DIFF
--- a/boards/bronco_space/proves_flight_control_board_v5e/proves_flight_control_board_v5e_rp2350a_m33.dts
+++ b/boards/bronco_space/proves_flight_control_board_v5e/proves_flight_control_board_v5e_rp2350a_m33.dts
@@ -55,9 +55,12 @@
 	 *                 in-tree Zephyr lora driver (semtech,sx1262) from
 	 *                 claiming this device.  LORA_BASICS_MODEM_DRIVERS
 	 *                 depends on !LORA so exactly one driver binds.
-	 *   spi-max-frequency: kept at 125000 Hz from the GRC bring-up value;
-	 *                 may be a board-level SPI signal-integrity workaround
-	 *                 (kept from v5e bring-up; revisit before production).
+	 *   spi-max-frequency: 4 MHz (SX1262 max 16 MHz).  The 125 kHz
+	 *                 bring-up value cost ~18 ms of SPI time per TX frame
+	 *                 (HWIL 2026-07-24: onPreTx config+FIFO upload 31 ms
+	 *                 at 125 kHz vs 12 ms at 4 MHz); validated on the HIL
+	 *                 bench with bidirectional P4_GFSK_75K link + 178 KB
+	 *                 file downlink (byte-identical, 1.53x throughput).
 	 *   tx/rx-enable-gpios: USP upstream has no external RF-switch support;
 	 *                 carried via our patch (spikes/patches/0001-feat-…).
 	 *   dio3-as-tcxo-control + tcxo-voltage: replaces dio3-tcxo-voltage in
@@ -68,13 +71,17 @@
 	lora0_usp: sx1262_usp@0 {
 		compatible = "semtech,sx1262-new";
 		reg = <0>;
-		spi-max-frequency = <125000>; /* kept from v5e bring-up; revisit */
+		spi-max-frequency = <4000000>; /* was 125000 (bring-up); HWIL-validated 2026-07-24 */
 		reset-gpios  = <&gpio0 6  GPIO_ACTIVE_LOW>;
 		busy-gpios   = <&gpio0 13 GPIO_ACTIVE_HIGH>;
 		dio1-gpios   = <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		dio3-as-tcxo-control;
 		tcxo-voltage     = <SX126X_TCXO_SUPPLY_1_8V>;
-		tcxo-wakeup-time = <10>;
+		tcxo-wakeup-time = <5>; /* was 10; radio planner sleeps the radio after every
+		                         * TX task, so this delay is paid per frame.  5 ms
+		                         * HWIL-validated 2026-07-24 (link + file integrity);
+		                         * confirm against the E22-400M30S TCXO startup spec
+		                         * before flight. */
 		reg-mode         = <SX126X_REG_MODE_LDO>;
 		rx-boosted;
 		tx-enable-gpios  = <&gpio0 21 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
## Summary
USP LoRa downlink at P4_GFSK_75K was software-limited to ~2.5 kB/s (~27% of PHY). Per-frame RAM-trace instrumentation on the HIL bench (probes at ComQueue hand-off, UspRadio deferred TX, RAC submit, onPreTx, set_tx, TX_DONE, comStatus) produced this breakdown of the ~97 ms/frame cadence:

| stage | 125 kHz baseline | 4 MHz | 4 MHz + TCXO 5 ms |
|---|---|---|---|
| comStatus -> next frame at radio | ~8.6 ms | 2.4 ms | 2.3 ms |
| dataIn -> deferred handler | 0.7 ms | 6.2 ms* | 6.1 ms* |
| stop/submit/RAC/planner | ~0.2 ms | ~0.3 ms | ~0.3 ms |
| onPreTx (SPI config + 249 B FIFO + set_tx) | **30.7 ms** | **12.2 ms** | **7.2 ms** |
| airtime (set_tx -> TX_DONE) | 27.8 ms | 27.8 ms | 27.8 ms |
| TX_DONE -> comStatus | 3.7 ms | 2.7 ms | 2.8 ms |

\* includes the deliberate bounded re-arm-skip wait; overlaps the pipeline hop.

Two board-DTS costs dominate the overhead:
1. `spi-max-frequency = 125000` (bring-up value) — ~18 ms/frame of pure SPI time.
2. `tcxo-wakeup-time = 10` — the radio planner sleeps the radio after **every** task, so the TCXO restart is paid per frame.

## Measurements (178,704 B `//dl200k.bin` SD-file downlink over RF, 248 B frames)
- baseline: 69.8-71.5 s (2500-2562 B/s), 181-214 RateGroupCycleSlip/run
- SPI 4 MHz: **45.79 s (3903 B/s)**, 1 cycle slip
- SPI 4 MHz + TCXO 5 ms: **41.44 s (4312 B/s, 1.72x)**, 5 cycle slips
- All downlinked files byte-identical (md5 911c2ce7...) to baseline copies
- Bidirectional link, authenticated RF commanding, and P0<->P4 profile switching re-verified after each change

## Caveats / follow-ups
- TCXO 5 ms is HWIL-validated but should be confirmed against the E22-400M30S TCXO startup spec before flight; keep 10 ms if the spec disagrees (SPI-only change alone is 1.53x).
- The structural fix — lazy radio sleep between back-to-back TX tasks in the radio planner (saves the remaining ~5-7 ms wake cost) — is a `usp` fork change, tracked separately.
- Remaining software floor after this PR is ~15 ms/frame (bounded re-arm window + residual SPI/handshake); airtime is now >60% of the frame period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)