### PR TITLE
chore(fprime-zephyr): bump pin to fc0d0f0 (GFSK wedge-fix host UTs)

### DIFF
--- a/PROVESFlightControllerReference/test/unit-tests/CMakeLists.txt
+++ b/PROVESFlightControllerReference/test/unit-tests/CMakeLists.txt
@@ -50,6 +50,18 @@ target_compile_definitions(test_RadioHeadShim PRIVATE LINK_PROFILES_USE_HOST_TYP
 target_link_libraries(test_RadioHeadShim gtest_main)
 add_test(NAME test_RadioHeadShim COMMAND test_RadioHeadShim)
 
+# --- UspRadio: TxOutcomePolicy host-side test (GFSK wedge-fix item 3) ---
+# TxOutcomePolicy.hpp is header-only and free of F'/USP/Zephyr includes.
+add_executable(test_TxOutcomePolicy
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/fprime-zephyr/fprime-zephyr/Drv/UspRadio/test/ut/test_TxOutcomePolicy.cpp
+)
+target_include_directories(test_TxOutcomePolicy PRIVATE
+    # Exposes #include "fprime-zephyr/Drv/UspRadio/TxOutcomePolicy.hpp"
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/fprime-zephyr
+)
+target_link_libraries(test_TxOutcomePolicy gtest_main)
+add_test(NAME test_TxOutcomePolicy COMMAND test_TxOutcomePolicy)
+
 # --- Helper Libraries ---
 
 # DetumbleManager BDot


### PR DESCRIPTION
## Summary
- Bumps the `lib/fprime-zephyr` submodule pin to `fc0d0f0` (integration head of `feat/usp-radio` in the OSSF fprime-zephyr fork), cascading fork PR #21's follow-up commit `8632dd4`.
- `8632dd4` adds host-side gtest coverage for item 2b of the test-hardening plan: the GFSK RX/TX wedge fix's `deferredTxPacket` comStatus decision (fix item 3 — report SUCCESS even after a failed send, so a single dropped frame never permanently parks `Svc::ComQueue` in WAITING; this was HWIL anomaly B Latch B, 2026-07-24).
- The comStatus decision is extracted into a new pure, header-only `TxOutcomePolicy.hpp` (`Drv/UspRadio/`), following the existing `RadioHeadShim.hpp` / `ProfilePolicy.hpp` host-testability pattern in this directory — no F´/USP/Zephyr includes, compiles in the host-UT harness unmodified. `UspRadio.cpp`'s `deferredTxPacket_internalInterfaceHandler()` now calls `TxOutcomePolicy::evaluate(rc)` instead of inlining the same branches — behavior-preserving refactor, not a rewrite.
- Registers `test_TxOutcomePolicy` in `PROVESFlightControllerReference/test/unit-tests/CMakeLists.txt`.

**Deviation, documented in the fprime-zephyr commit:** fix items 1 and 2 (`quiesceRadio()` chip-level standby+IRQ-clear postcondition, and the `transmitPacket()` TX_DONE-timeout task-abort/quiesce recovery) live entirely inside `RalSessionImpl.cpp`, which is compiled only under `CONFIG_LORA_BASICS_MODEM_DRIVERS` and unconditionally excluded from host builds (calls `smtc_rac_*`/`radio_planner_t` USP-SDK internals with no host-compilable representation). A faithful seam for those two paths would need a mock RAC/RP layer standing in for real Semtech SDK structs — out of scope for a minimal, behavior-preserving refactor. They remain covered by PR #21's HWIL validation (pre-fix repro + post-fix 32-switch matrix + rung-9 rerun + rung-10 24h soak).

## Test plan
- [x] `make test-unit` — 12/12 passed (was 11/11; new `test_TxOutcomePolicy` adds 6 cases, including a regression guard sweeping arbitrary `rc` values asserting comStatus is never FAILURE)
- [x] Standalone g++/gtest compile of `test_TxOutcomePolicy.cpp` against the fix branch header, 6/6 passed, before cascading into the integration branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)