### PR TITLE
chore(pins): re-pin zephyr + fprime-zephyr onto trimmed integration branches

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -15,11 +15,15 @@ manifest:
 
   projects:
     # Zephyr RTOS core — Open-Source-Space-Foundation fork, integration branch
-    # feat/proves-usp-radio (v4.4.1 + CDC-ACM fixes, formerly patches/0005+0007;
-    # constituent PRs tracked in OSSF/zephyr#3).
+    # feat/proves-usp-radio-trimmed (v4.4.1 + the CDC-ACM TX-FIFO drain fix,
+    # formerly patches/0005; constituent PR tracked in OSSF/zephyr#1).
+    # The poll_out bounded-wait layer (OSSF/zephyr#2) was pruned 2026-08-01:
+    # its added bound sits behind data->flow_ctrl, which is false on the v5e
+    # from both devicetree and the explicit UART_CFG_FLOW_CTRL_NONE configure,
+    # so the code was unreachable in the flight image.
     - name: zephyr
       url: https://github.com/Open-Source-Space-Foundation/zephyr
-      revision: 3838a2802c916accdfa671de77633ee45b69441c
+      revision: 144acbce8713ff856e15577487b8bd5dd571c5c2
       path: lib/zephyr-workspace/zephyr
       west-commands: scripts/west-commands.yml
       import:


### PR DESCRIPTION
Drops two changes from the USP radio changeset as part of the pre-merge
blast-radius trim. Both were pruned on the merits; neither costs any
measured throughput.

fprime-zephyr c81485f -> 3da24b8 (feat/proves-usp-radio-trimmed)
  Removes the re-arm semaphore (OSSF/fprime-zephyr#19, closed). It had a
  measured null result — 35.8 s before and after, 1.00x on the downlink
  ladder — and the PR body itself retracted its premise: the k_sleep poll
  it replaced never actually slept at saturation.

  The GFSK RX->TX wedge fix (#23) was rebased off it onto feat/usp-radio.
  Verified: the rebased tree differs from the pre-trim tree by exactly the
  semaphore's 30 lines in UspRadio.cpp — quiesceRadio(), the TX_DONE
  timeout recovery, the comStatus-SUCCESS-after-drop path and the
  TxOutcomePolicy UTs are all intact. P5_GMSK_83K (#20, draft) was rebased
  onto the new #23 head and is retained unchanged.

zephyr 3838a28 -> 144acbc (feat/proves-usp-radio-trimmed)
  Removes the cdc_acm poll_out bounded wait (OSSF/zephyr#2, closed). The
  added bound sits behind data->flow_ctrl, which is false on the v5e from
  both directions: hw-flow-control is absent from the cdc_acm_uart0 node
  (verified in the generated devicetree, not just source), and the sole
  uart_configure() caller sets UART_CFG_FLOW_CTRL_NONE. The code was
  unreachable in the flight image.

  The TX-FIFO drain fix (#1) is explicitly RETAINED — it is reachable
  wherever a USB host is enumerated, which includes the self-hosted
  integration-uart/integration-radio runners and their Korad power-cycle
  and re-enumeration steps. Fork delta drops from +21/-1 to +11/-0.

Old branches feat/proves-usp-radio are retained on both forks pending
review of this pin; pruned branches are retained for recoverability.

Co-Authored-By: Claude <noreply@anthropic.com>

---

Part of the pre-merge blast-radius trim of the USP radio changeset (tracking: #439).

**Verification done before opening:**
- fprime-zephyr: rebased tree differs from pre-trim by exactly the semaphore's 30 lines; wedge fix + UTs byte-intact.
- zephyr: fork delta vs `v4.4.1-base` confirmed `+11/-0` (drain only) vs `+21/-1` before.

**Still needed:** build + unit tests + full CI on this pin, and a bench smoke. Because neither pruned change is on the throughput ladder, the expected downlink number is unchanged at ~36.08 s / 4,953 B/s — this pin should not move perf at all, which is itself the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)