### PR TITLE
fix(build): pin pre-commit's Python to .python-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ zephyr-setup: fprime-venv ## Set up Zephyr environment
 
 .PHONY: pre-commit-install
 pre-commit-install: uv ## Install pre-commit hooks
-	@$(UVX) pre-commit install > /dev/null
+	@$(UVX_PINNED) pre-commit install > /dev/null
 
 .PHONY: fmt
 fmt: pre-commit-install ## Lint and format files
-	@$(UVX) pre-commit run --all-files
+	@$(UVX_PINNED) pre-commit run --all-files
 
 .PHONY: data-budget
 data-budget: fprime-venv ## Analyze telemetry data budget (use VERBOSE=1 for detailed output)

--- a/makelib/build-tools.mk
+++ b/makelib/build-tools.mk
@@ -10,10 +10,19 @@ $(TOOLS_DIR):
 ### Tool Versions
 UV_VERSION ?= 0.8.13
 
+### Python version used for tooling environments. Single source of truth is .python-version, so
+### that tools do not silently build against whichever interpreter happens to be on the machine.
+PYTHON_VERSION ?= $(shell cat .python-version)
+
 ### uv & uvx
 UV_DIR ?= $(TOOLS_DIR)/uv-$(UV_VERSION)
 UV ?= $(UV_DIR)/uv
 UVX ?= $(UV_DIR)/uvx
+### Pin the interpreter for uvx-run tooling. pre-commit builds its hook environments with whatever
+### Python runs it, so without this a machine defaulting to an older interpreter builds hook
+### environments that cannot parse project sources written for .python-version. uv downloads the
+### pinned interpreter if it is missing.
+UVX_PINNED ?= $(UVX) --python $(PYTHON_VERSION)
 .PHONY: uv
 uv: $(UV) ## Download uv
 $(UV): $(TOOLS_DIR)


### PR DESCRIPTION
## Problem

`make fmt` fails on some machines with a `SyntaxError` in a file the caller never touched:

```
File "<unknown>", line 195
    assert updated_time > initial_time, f"Time should increase. Initial: {
                                        ^
SyntaxError: unterminated string literal (detected at line 195)
```

`pre-commit` builds its hook environments with whatever interpreter happens to run it, and nothing in this repo pinned that. On a machine where `uvx` resolves an older Python, the `interrogate` hook gets built against it — and `PROVESFlightControllerReference/test/int/rtc_test.py:195` uses a multi-line f-string, which is valid under the project's declared Python (3.13, [PEP 701](https://peps.python.org/pep-0701/)) but a syntax error under 3.11.

CI happens to resolve a new enough interpreter, so `main` is green and this only bites locally, and only on some machines. That makes it easy to mistake for a problem with your own branch.

## Fix

Pin the interpreter for `uvx`-run tooling to `.python-version`, keeping one source of truth rather than hardcoding a version in the Makefile. `uv` downloads the pinned interpreter when it is missing, so this requires no setup from contributors.

Applied to both `fmt` and `pre-commit-install`, so the installed git hook and the `make` target agree.

## Alternative considered

Rewriting the f-string in `rtc_test.py` to parse under 3.11 would clear the immediate error, but it treats the symptom — the next 3.12+ construct anyone writes breaks unpinned environments again, and the repo already requires 3.13+. Pinning fixes the class of problem. Happy to do both if reviewers prefer belt and braces.

## Verification

With the `interrogate` hook cache cleared, so environments are genuinely rebuilt rather than reused:

```
$ rm -rf ~/.cache/pre-commit/repoe_1791ec/py_env-python3
$ make fmt
[INFO] Installing environment for https://github.com/econchick/interrogate/.
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check json...............................................................Passed
check for added large files..............................................Passed
codespell................................................................Passed
clang-format.............................................................Passed
cpplint..................................................................Passed
ruff check...............................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
interrogate..............................................................Passed
Sync SDD docs to docs-site...............................................Passed
```

Build-tooling only — no firmware, component, or test sources are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kehXMi9zAAoPJ3PgfRd81