### PR TITLE
fix(test): guard YAMCS event subscription teardown against websocket race

### DIFF
--- a/PROVESFlightControllerReference/test/yamcs/test_yamcs_noop.py
+++ b/PROVESFlightControllerReference/test/yamcs/test_yamcs_noop.py
@@ -11,6 +11,7 @@ matching NoOpReceived event come back through the YAMCS event subscription,
 the full TC + TM + events path is healthy.
 """
 
+import logging
 import queue
 import time
 
@@ -71,4 +72,15 @@ def test_noop_round_trip(yamcs_client, yamcs_processor, yamcs_instance):
             f"{TOTAL_TIMEOUT_S}s after {attempts} CMD_NO_OP attempts"
         )
     finally:
-        subscription.cancel()
+        # websocket-client's WebSocketApp.close() has a check-then-use race on
+        # self.sock: the reader thread can null it between the truthiness check
+        # and the close_frame read, raising AttributeError out of teardown.  A
+        # teardown error would replace this test's real result (pass, or the
+        # AssertionError above) with a misleading traceback, so swallow it.
+        try:
+            subscription.cancel()
+        except Exception:  # noqa: BLE001 - teardown must not mask the test result
+            logging.getLogger(__name__).warning(
+                "Ignoring error while cancelling YAMCS event subscription",
+                exc_info=True,
+            )


### PR DESCRIPTION
Fixes the recurring `integration-uart` failure tracked in #514.

## Root cause

The round-trip test was **passing** and then failing in teardown. In both failing runs the whole test completed in about a second (`1 failed in 0.97s`, `1 failed in 1.03s`) — far inside the 180 s budget — meaning the `NoOpReceived` event was observed and the test returned normally. The only exception came from `subscription.cancel()` in the `finally` block:

```
finally:
>   subscription.cancel()
...
websocket/_app.py:211: AttributeError: 'NoneType' object has no attribute 'close_frame'
```

`WebSocketApp.close()` has a check-then-use race on `self.sock`:

```python
if self.sock:
    self.sock.close(**kwargs)              # wakes the reader thread, which sets self.sock = None
    if self.sock.close_frame is not None:  # dereferenced again -> AttributeError
```

The race is still present in `websocket-client` 1.9.1, so bumping the dependency does not help.

## Corrections to the analysis in #514

- **"Subscription never established"** — not possible: `create_event_subscription` blocks on `subscription.reply(timeout=60)`, so a failed handshake raises at subscription time rather than yielding a silently empty queue. No readiness check is needed.
- **"Test burned the full timeout"** — it did not; see the sub-second durations above.
- **"`AssertionError` was the real failure, masked by teardown"** — inverted. The `AssertionError` was never raised; pytest was only echoing the test's source in the traceback context. Teardown was the sole failure.
- **"Bump `yamcs-client` 1.12.1"** — wrong layer, and the bug is unpatched upstream anyway.

Only the "guard the teardown" suggestion from the issue holds, and it is the complete fix.

## Change

Wrap `subscription.cancel()` in try/except and log at warning level, so a teardown error can never replace the test's real result.

## Evidence

Attempt-1 logs of runs 33270707473 and 33325337362: identical traceback, both sub-second, both raised through `finally: subscription.cancel()`.

## Out of scope

`main` has been red on `integration-uart` since the F Prime 4.3.0 upgrade, but that failure occurs at the **UART pytest** step, before YAMCS starts — a different signature, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBD3NFb2h8TxkuxrfSRyhS