### PR TITLE
Upgrade to Zephyr 4.4.2 and bump mbedtls, tf-psa-crypto, fatfs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -17,7 +17,7 @@ manifest:
     # Zephyr RTOS core
     - name: zephyr
       repo-path: zephyr
-      revision: v4.4.1
+      revision: v4.4.2
       path: lib/zephyr-workspace/zephyr
       west-commands: scripts/west-commands.yml
       import:

--- a/west.yml
+++ b/west.yml
@@ -68,13 +68,13 @@ manifest:
 
     # Crypto libraries (commonly used)
     - name: mbedtls
-      revision: a3e190fe44c78d1ba67f55979e1257328cc7d0d8
+      revision: 098e120afb51877ed814bdc04443890ae12e0642
       path: lib/zephyr-workspace/modules/crypto/mbedtls
       groups:
         - crypto
 
     - name: tf-psa-crypto
-      revision: dc575a2ddcc8cb16275d24c42a52eaf79ebe2231
+      revision: fa92349590a54959ee2efc21b668e5afdb144726
       path: lib/zephyr-workspace/modules/crypto/mbedtls/tf-psa-crypto
       groups:
         - crypto

--- a/west.yml
+++ b/west.yml
@@ -84,7 +84,7 @@ manifest:
       path: lib/zephyr-workspace/bootloader/mcuboot
 
     - name: fatfs
-      revision: f4ead3bf4a6dab3a07d7b5f5315795c073db568d
+      revision: 4f60a12c58c3de4246857ad87c40239ecd93349b
       path: lib/zephyr-workspace/modules/fatfs
 
   self:


### PR DESCRIPTION
Bumps the west manifest and the `lib/zephyr-workspace/zephyr` submodule from v4.4.1 to [v4.4.2](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v4.4.2), a 197-commit security and bugfix release on the v4.4 branch, then moves three module pins.

Three commits, reviewable independently.

## 1. Zephyr 4.4.2

Of the ten modules this trimmed manifest imports, none of their revisions moved between the two tags — the only change in upstream's `west.yml` is `hal_espressif`, which we don't import. So the upgrade itself is one manifest line plus the submodule pointer.

4.4.2 includes `c219dde148e modules: mcuboot: kconfig: Fix RAM revert image confirmed image`, which touches OTA swap logic. Given this repo's history with swap behavior, that's the piece worth exercising on hardware.

## 2. mbedtls + tf-psa-crypto → Mbed TLS 4.1.1 / TF-PSA-Crypto 1.1.1

These are the revisions Zephyr's `v4.4-branch` moved to after tagging 4.4.2 — the only module movement on the stable branch, so this is what 4.4.3 will ship. Taking it now keeps us on the tested combination rather than ahead of it.

TF-PSA-Crypto 1.1.1 carries six CVEs, but **none reach either image as configured**, so this is housekeeping rather than an urgent fix. The application enables only HMAC and SHA-256 (`prj.conf:94-96`); the bootloader only RSA-PSS verify with SHA-256. The CVEs are in RSA PKCS#1 v1.5 *decryption*, RSA key *generation*, ChaCha20, x25519/Everest ECDH, ECC scalar multiplication, and ECC public-key parsing — no ECC, no ChaCha, no private-key operations, no on-device keygen. Image sizes are unchanged, consistent with that analysis.

## 3. fatfs → `4f60a12c` (ahead of the manifest)

This one is a deliberate divergence and the reason it's worth merging now rather than waiting.

Five FatFs CVEs were fixed in July 2026 but **did not make 4.4.2, and are not on `v4.4-branch`** — 4.4.3 won't pick them up either. Our pin dates to October 2025 and is a pristine ChaN R0.16 with none of them applied (verified: `MIN_EXFAT`, `MIN_VOLUME`, `fill_zero` all absent).

Three are mount-time validation, and the flight filesystem is FAT with exFAT enabled:

| CVE | Defect |
|---|---|
| 2026-6682 | `BPB_FATSz32` × FAT count overflowed a DWORD, laying the data region inside the FAT |
| 2026-6683 (exFAT) | BPB reporting zero clusters → `sync_fs()` divides by zero on first write or unmount |
| 2026-6687 (exFAT) | `f_getlabel()` looped over an unvalidated on-disk count, overrunning the caller's buffer |

The realistic trigger here isn't an attacker-supplied volume — it's **a superblock torn by a hard reset**, the same corruption class that motivated the boot-count hardening in #470. Today a malformed BPB faults; with these patches it's rejected at mount, and `CONFIG_FS_FATFS_MOUNT_MKFS=y` reformats and recovers.

A fourth, CVE-2026-6686, zeroes the range exposed when `f_lseek()` extends a file past EOF, which previously read back stale flash contents. The fifth (CVE-2026-6685) upstream documents as a readability change, not a fix.

The six commits touch only `ff.c` and docs, so there's no Zephyr-side glue to adapt.

## Verification

- `west update` — all projects at their expected revisions
- `make build` — clean. Application FLASH 64.70% (675,560 B, +280 B from fatfs `fill_zero`), RAM 56.70% (unchanged)
- `make check-console-disabled` — OK, console still off so the downlink stays frames-only
- `make build-mcuboot` — clean. Bootloader FLASH 8.96% (93,516 B), RAM 8.97%

## Still to do before this leaves draft

- [x] Bench run of the OTA swap test, given the MCUboot Kconfig fix in 4.4.2
- [x] Full integration suite on hardware, with attention to filesystem mount/format paths given the fatfs change
